### PR TITLE
Expose pp_sat_conj_as_dot

### DIFF
--- a/lib/constraints/src/implementation/constraints_implementation.ml
+++ b/lib/constraints/src/implementation/constraints_implementation.ml
@@ -29,6 +29,7 @@ module type S = sig
   val quantify_over : Var.t -> t -> t list
 
   val pp : Format.formatter -> t -> unit
+  val pp_as_dot : name:string -> Format.formatter -> t -> unit
 end
 
 module Dummy = (Dummy : S)

--- a/lib/constraints/src/implementation/dummy.ml
+++ b/lib/constraints/src/implementation/dummy.ml
@@ -26,3 +26,4 @@ let nsim _ _ _ () = [()]
 let quantify_over _ () = [()]
 
 let pp _ _ = ()
+let pp_as_dot ~name _ _ = ignore name

--- a/lib/constraints/src/implementation/efficient.ml
+++ b/lib/constraints/src/implementation/efficient.ml
@@ -26,3 +26,4 @@ let nsim _x _fs _y _c = assert false
 let quantify_over _x _c = assert false
 
 let pp _ _ = assert false
+let pp_as_dot ~name _ _ = ignore name; assert false

--- a/lib/constraints/src/implementation/naive/constraints_implementation_naive.ml
+++ b/lib/constraints/src/implementation/naive/constraints_implementation_naive.ml
@@ -31,3 +31,4 @@ let sim x fs y = add (Pos (Sim (x, fs, y)))
 let nsim x fs y = add (Neg (Sim (x, fs, y)))
 
 let pp = Conj.pp
+let pp_as_dot = Conj.pp_as_dot

--- a/lib/constraints/src/interface.ml
+++ b/lib/constraints/src/interface.ml
@@ -61,6 +61,7 @@ module type S = sig
      might be empty when ([c] &and; [f]) is unsatisfiable. *)
 
   val pp_sat_conj : Format.formatter -> sat_conj -> unit
+  val pp_sat_conj_as_dot : name:string -> Format.formatter -> sat_conj -> unit
 
   val quantify_over : Var.t -> sat_conj -> sat_conj list
 end
@@ -174,6 +175,7 @@ module Make (I : Constraints_implementation.S) : S = struct
     | Path.Rel q -> similar_normal r r' Path.(normalize (concat cwd q)) z z'
 
   let pp_sat_conj = I.pp
+  let pp_sat_conj_as_dot = I.pp_as_dot
 
   let quantify_over = I.quantify_over
 end


### PR DESCRIPTION
I've not reworked the DOT yet. Tbh, I don't remember how it looks like. But `pp_sat_conj_as_dot` is now exposed.

fix #62