### PR TITLE
Command line arguments

### DIFF
--- a/src/colis.ml
+++ b/src/colis.ml
@@ -17,7 +17,10 @@ module Concrete = struct
   module Stdin = Semantics__Buffers.Stdin
   module Stdout = Semantics__Buffers.Stdout
   module Context = Semantics__Context
-  module Env = Semantics__Env
+  module Env = struct
+    include Semantics__Env
+    let update = mixfix_lblsmnrb
+  end
   module Input = Semantics__Input
   module Semantics = Semantics__Semantics
   module Filesystem = Interpreter__Filesystem
@@ -101,7 +104,7 @@ let colis_to_file filename colis =
 let mk_concrete_var_env =
   let open Concrete.Env in
   List.fold_left
-    (fun env (var, val_) -> mixfix_lblsmnrb env var val_)
+    (fun env (var, val_) -> update env var val_)
     (empty_env "")
 
 let run ~argument0 ?(arguments=[]) ?(vars=[]) colis =

--- a/src/colis.mli
+++ b/src/colis.mli
@@ -78,7 +78,7 @@ val pp_print_colis : Format.formatter -> colis -> unit
 
 (** {2 Interpreting} *)
 
-val run : argument0:string -> ?arguments:(string list) -> colis -> unit
+val run : argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> unit
 (** Runs a Colis program.
 
     @param argument0 Value for argument zero (the interpreter or filename)
@@ -96,5 +96,5 @@ type symbolic_config = {
   (** Maximum height of the call stack in symbolic execution *)
 }
 
-val run_symbolic : symbolic_config -> argument0:string -> ?arguments:(string list) -> colis -> unit
+val run_symbolic : symbolic_config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> unit
 (** Symbolically executes a Colis program. *)

--- a/src/colis.mli
+++ b/src/colis.mli
@@ -17,7 +17,11 @@ module Concrete: sig
   module Context = Semantics__Context
   module Stdin = Semantics__Buffers.Stdin
   module Stdout = Semantics__Buffers.Stdout
-  module Env = Semantics__Env
+  module Env : sig
+    include module type of Semantics__Env
+    val update : (string -> 'a) -> string -> 'a -> (string -> 'a)
+    (** Alias for the auto-generated name [mixfix_lblsmsrb] *)
+  end
   module Input = Semantics__Input
   module Semantics = Semantics__Semantics
   module Filesystem = Interpreter__Filesystem

--- a/src/colis_cmd.ml
+++ b/src/colis_cmd.ml
@@ -27,7 +27,7 @@ let get_source, set_source =
     | None -> source := Some new_source
     | Some _ -> raise (Arg.Bad "only one source among --colis and --shell can be specified"))
 
-let get_file, get_arguments, set_file_or_argument =
+let get_file, get_arguments, set_file_or_argument, add_argument =
   let file = ref None in
   let args = ref [] in
   (fun () ->
@@ -38,7 +38,8 @@ let get_file, get_arguments, set_file_or_argument =
   (fun new_file_or_arg ->
     match !file with
     | None -> file := Some new_file_or_arg
-    | Some _ -> args := new_file_or_arg :: !args)
+    | Some _ -> args := new_file_or_arg :: !args),
+  (fun arg -> args := arg :: !args)
 
 let prune_init_state = ref false
 let loop_limit = ref 10
@@ -73,11 +74,12 @@ let speclist =
     "--stack-size",                Int ((:=) stack_size),         sprintf "SIZE Set the stack size for symbolic execution to SIZE (default: %d)" !stack_size;
     "--print-states",              String ((:=)print_states_dir), "DIR Save symbolic states as dot files in directory DIR";
     "--fail-on-unknown-utilities", Set fail_on_unknown_utilities, " Unknown utilities kill the interpreter";
+    "--",                          Rest add_argument,             "ARG... Pass argument (starting with a dash) to the CoLiS interpreter";
   ]
 
 let usage =
   sprintf
-    ("Usage: %s [--run <run-options> | --run-symbolic <symbolic-run-options> | --print-colis | --print-shell] <parsing-options> FILE [ARGS]\n"^^
+    ("Usage: %s [--run <run-options> | --run-symbolic <symbolic-run-options> | --print-colis | --print-shell] <parsing-options> FILE [--] [ARG...]\n"^^
      "       <run-options>: [--realworld |  --fail-on-unknown-utilities]\n"^^
      "       <symbolic-run-options>: [--symbolic-fs FS] [--prune-init-state] [--loop-boundary] [--fail-on-unknown-utilities] [--print-states DIR]\n"^^
      "       <parsing-options>: [--shell [--external-sources DIR] | --colis]")

--- a/src/colis_cmd.ml
+++ b/src/colis_cmd.ml
@@ -88,7 +88,7 @@ let speclist =
     "--stack-size",                Int ((:=) stack_size),         sprintf "SIZE Set the stack size for symbolic execution to SIZE (default: %d)" !stack_size;
     "--print-states",              String ((:=)print_states_dir), "DIR Save symbolic states as dot files in directory DIR";
     "--fail-on-unknown-utilities", Set fail_on_unknown_utilities, " Unknown utilities kill the interpreter";
-    "--",                          Rest add_argument,             "ARG... Pass all further arguments directory to the CoLiS interpreter";
+    "--",                          Rest add_argument,             "ARG... Pass all further arguments directly to the CoLiS interpreter";
   ]
 
 let usage =

--- a/src/concrete/interpreter/why3session.xml
+++ b/src/concrete/interpreter/why3session.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE why3session PUBLIC "-//Why3//proof session v5//EN"
 "http://why3.lri.fr/why3session.dtd">
 <why3session shape_version="5">
-<prover id="0" name="Z3" version="4.6.0" timelimit="1" memlimit="1000"/>
+<prover id="0" name="Z3" version="4.6.0" timelimit="1" steplimit="1" memlimit="1000"/>
 <prover id="1" name="Alt-Ergo" version="2.2.0" timelimit="1" steplimit="62" memlimit="1000"/>
-<prover id="2" name="CVC4" version="1.6" timelimit="1" memlimit="1000"/>
+<prover id="2" name="CVC4" version="1.6" timelimit="1" steplimit="1" memlimit="1000"/>
 <file proved="true">
 <path name=".."/>
 <path name="interpreter.mlw"/>
@@ -280,7 +280,7 @@
      <goal name="VC interp_instruction.61.0.1.0" expl="apply premises" proved="true">
      <transf name="assert" proved="true" arg1="(ctx1&#39;=context sta1)">
       <goal name="VC interp_instruction.61.0.1.0.0" expl="asserted formula" proved="true">
-      <proof prover="2"><result status="valid" time="0.82"/></proof>
+      <proof prover="2" timelimit="10" steplimit="0"><result status="valid" time="0.82"/></proof>
       </goal>
       <goal name="VC interp_instruction.61.0.1.0.1" expl="apply premises" proved="true">
       <proof prover="2"><result status="valid" time="0.23"/></proof>

--- a/src/symbolic/symbolicInterpreter.mlw
+++ b/src/symbolic/symbolicInterpreter.mlw
@@ -92,6 +92,7 @@ module Context
   type var_env = Env.t string
   type func_env = Env.t instruction
 
+
   type context = {
     var_env: var_env;
     func_env: func_env;


### PR DESCRIPTION
This PR allows (for concrete and symbolic interpreter)
- giving arguments to the interpreter (e.g. for `$1`) even when they start with a dash (they were matched with arguments to the command line tool before)
- defining variables from the command line. Example

```shell
$ cat test.sh
echo $0: $1/$2/$a/$b
$ ./bin/colis --var a=X --var b=B --var a=A test.sh one -- --two
test.sh: one/--two/A/B
```