### PR TITLE
Use incompleteness behaviour

### DIFF
--- a/src/colis.ml
+++ b/src/colis.ml
@@ -103,9 +103,15 @@ let run ~argument0 ?(arguments=[]) colis =
   let input = { Input.empty with argument0 } in
   let state = Interpreter.empty_state () in
   state.arguments := arguments;
-  Interpreter.interp_program input state colis;
+  let code =
+    try
+      Interpreter.interp_program input state colis;
+      if !(state.result) then 0 else 1
+    with Interpreter.EFailure ->
+      10
+  in
   print_string (Stdout.all_lines !(state.stdout) |> List.rev |> String.concat "\n");
-  exit (if !(state.result) then 0 else 1)
+  exit code
 
 let print_symbolic_filesystem fmt fs =
   let open Constraints in

--- a/src/colis.ml
+++ b/src/colis.ml
@@ -107,7 +107,7 @@ let run ~argument0 ?(arguments=[]) colis =
     try
       Interpreter.interp_program input state colis;
       if !(state.result) then 0 else 1
-    with Interpreter.EFailure ->
+    with Interpreter.EIncomplete ->
       10
   in
   print_string (Stdout.all_lines !(state.stdout) |> List.rev |> String.concat "\n");

--- a/src/colis_cmd.ml
+++ b/src/colis_cmd.ml
@@ -66,19 +66,18 @@ let speclist =
     "--external-sources",          Set_string external_sources,   "DIR Import absolute sources from DIR";
     "--print-colis",               Unit (set_action PrintColis),  " Print the CoLiS script";
     "--print-shell",               Unit (set_action PrintShell),  " Print the Shell script";
-    "--realworld",                 Set real_world,                 " Use system utilities in concrete execution";
+    "--realworld",                 Set real_world,                 " Use system utilities in concrete execution (not implemented yet)";
     "--symbolic-fs",               String set_symbolic_fs,        "FS Name of the initial symbolic filesystem in symbolic execution (values: empty, simple, fhs, default: empty)";
     "--prune-init-state",          Set prune_init_state,          " Prune the initial state in symbolic execution";
     "--loop-limit",                Int ((:=) loop_limit),         sprintf "LIMIT Set limit for symbolic execution of while loops to LIMIT (default: %d)" !loop_limit;
     "--stack-size",                Int ((:=) stack_size),         sprintf "SIZE Set the stack size for symbolic execution to SIZE (default: %d)" !stack_size;
     "--print-states",              String ((:=)print_states_dir), "DIR Save symbolic states as dot files in directory DIR";
-    "--fail-on-unknown-utilities", Set fail_on_unknown_utilities, " Unknown utilities kill the interpreter";
   ]
 
 let usage =
   sprintf
     ("Usage: %s [--run <run-options> | --run-symbolic <symbolic-run-options> | --print-colis | --print-shell] <parsing-options> FILE [ARGS]\n"^^
-     "       <run-options>: [--realworld |  --fail-on-unknown-utilities]\n"^^
+     "       <run-options>: [--realworld]\n"^^
      "       <symbolic-run-options>: [--symbolic-fs FS] [--prune-init-state] [--loop-boundary] [--fail-on-unknown-utilities] [--print-states DIR]\n"^^
      "       <parsing-options>: [--shell [--external-sources DIR] | --colis]")
     Sys.argv.(0)
@@ -89,8 +88,6 @@ let main () =
   Arg.parse speclist set_file_or_argument usage;
   if !Colis.Options.real_world && get_action () <> Run then
     raise (Arg.Bad "--realworld can only be specified with --run");
-  if !Colis.Options.fail_on_unknown_utilities && (get_action () <> Run && get_action () <> RunSymbolic) then
-    raise (Arg.Bad "--fail-on-unknown-utilities can only be specified with --run or --run-symbolic");
   if !prune_init_state && get_action () <> RunSymbolic then
     raise (Arg.Bad "--prune-init-state can only be specified with --run-symbolic");
 
@@ -156,11 +153,3 @@ let () =
   | ConversionError msg ->
      eprintf "Conversion error: %s@." msg;
      exit 6
-
-  | UnsupportedUtility (name, msg) ->
-     eprintf "%s: %s@." name msg;
-     exit 7
-
-  | UnsupportedArgument (name, msg, arg) ->
-     eprintf "%s: %s: %s@." name msg arg;
-     exit 8

--- a/src/concrete/interpreter.mlw
+++ b/src/concrete/interpreter.mlw
@@ -117,19 +117,25 @@ module Interpreter
 
   let interp_utility (inp:input) (sta:state) (id:identifier) (args:list string)
     returns { () -> 
-      interp_utility (old state sta) id args = (state sta, !(sta.result)) /\
+      interp_utility (old state sta) id args = (state sta, S.Result !(sta.result)) /\
       behaviour inp !(sta.result) = BNormal
     }
     raises { EExit -> 
-      interp_utility (old state sta) id args = (state sta, !(sta.result)) /\
+      interp_utility (old state sta) id args = (state sta, S.Result !(sta.result)) /\
       behaviour inp !(sta.result) = BExit
     }
-  = let sta', b = interp_utility (state sta) id args in
-    sta.filesystem := sta'.S.filesystem;
+    raises { EFailure -> true }
+  = let sta', res = interp_utility (state sta) id args in
     sta.stdin := sta'.S.stdin;
     sta.stdout := sta'.S.stdout;
-    sta.result := b;
-    maybe_exit inp sta
+    match res with
+    | S.Ok b ->
+      sta.filesystem := sta'.S.filesystem;
+      sta.result := b;
+      maybe_exit inp sta
+    | S.Failure ->
+      raise EFailure
+    end
 
   use semantics.Arguments
 
@@ -182,6 +188,7 @@ module Interpreter
       eval_instruction 0 (cnf, inp, context (old sta), state (old sta))
         ins (state sta, context sta, BExit)
     }
+    raises { EFailure -> true }
   = label L in match ins with
 
     | IExit code ->
@@ -370,6 +377,7 @@ module Interpreter
       eval_str_expr 0 b (cnf, inp, context (old sta), state (old sta))
         se (state sta, Some (s, b'))
     }
+    raises { EFailure -> true }
   = match se with
 
     | SLiteral s ->
@@ -412,6 +420,7 @@ module Interpreter
       eval_list_expr 0 (cnf, inp, context (old sta), state (old sta))
         le (state sta, Some ss)
     }
+    raises { EFailure -> true }
   = match le with
     | Nil -> Nil
     | Cons (se, sp) le_rest ->
@@ -429,6 +438,7 @@ module Interpreter
       eval_program (cnf, inp, context (old sta), state (old sta))
         pro (state sta, Some !(sta.result))
     }
+    raises { EFailure -> true }
   = try
       let fenv = interp_function_definitions sta.func_env pro.function_definitions in
       interp_instruction inp { sta with func_env = fenv } pro.instruction

--- a/src/concrete/interpreter.mlw
+++ b/src/concrete/interpreter.mlw
@@ -101,7 +101,7 @@ module Interpreter
 
   exception EExit
   exception EReturn
-  exception EFailure
+  exception EIncomplete
 
   let maybe_exit (inp:input) (sta:state) : unit
     returns { () ->
@@ -124,17 +124,17 @@ module Interpreter
       interp_utility (old state sta) id args = (state sta, S.Result !(sta.result)) /\
       behaviour inp !(sta.result) = BExit
     }
-    raises { EFailure -> true }
+    raises { EIncomplete -> true }
   = let sta', res = interp_utility (state sta) id args in
     sta.stdin := sta'.S.stdin;
     sta.stdout := sta'.S.stdout;
     match res with
-    | S.Ok b ->
+    | S.Result b ->
       sta.filesystem := sta'.S.filesystem;
       sta.result := b;
       maybe_exit inp sta
-    | S.Failure ->
-      raise EFailure
+    | S.Incomplete ->
+      raise EIncomplete
     end
 
   use semantics.Arguments
@@ -188,7 +188,7 @@ module Interpreter
       eval_instruction 0 (cnf, inp, context (old sta), state (old sta))
         ins (state sta, context sta, BExit)
     }
-    raises { EFailure -> true }
+    raises { EIncomplete -> true }
   = label L in match ins with
 
     | IExit code ->
@@ -375,9 +375,9 @@ module Interpreter
     ensures { context sta = context (old sta) }
     returns { s, b' ->
       eval_str_expr 0 b (cnf, inp, context (old sta), state (old sta))
-        se (state sta, Some (s, b'))
+        se (state sta, S.Result (s, b'))
     }
-    raises { EFailure -> true }
+    raises { EIncomplete -> true }
   = match se with
 
     | SLiteral s ->
@@ -407,9 +407,9 @@ module Interpreter
 
     | SConcat se1 se2 ->
       label L1 in let s1, b1 = interp_str_expr b inp sta se1 in
-      assert { eval_str_expr 0 b (cnf, inp, context sta, state sta at L1) se1 (state sta, Some (s1, b1)) };
+      assert { eval_str_expr 0 b (cnf, inp, context sta, state sta at L1) se1 (state sta, S.Result (s1, b1)) };
       label L2 in let s2, b2 = interp_str_expr b1 inp sta se2 in
-      assert { eval_str_expr 0 b1 (cnf, inp, context sta, state sta at L2) se2 (state sta, Some (s2, b2)) };
+      assert { eval_str_expr 0 b1 (cnf, inp, context sta, state sta at L2) se2 (state sta, S.Result (s2, b2)) };
       s1^s2, b2
     end
 
@@ -418,9 +418,9 @@ module Interpreter
     ensures { context sta = context (old sta) }
     returns { ss ->
       eval_list_expr 0 (cnf, inp, context (old sta), state (old sta))
-        le (state sta, Some ss)
+        le (state sta, S.Result ss)
     }
-    raises { EFailure -> true }
+    raises { EIncomplete -> true }
   = match le with
     | Nil -> Nil
     | Cons (se, sp) le_rest ->
@@ -438,7 +438,7 @@ module Interpreter
       eval_program (cnf, inp, context (old sta), state (old sta))
         pro (state sta, Some !(sta.result))
     }
-    raises { EFailure -> true }
+    raises { EIncomplete -> true }
   = try
       let fenv = interp_function_definitions sta.func_env pro.function_definitions in
       interp_instruction inp { sta with func_env = fenv } pro.instruction

--- a/src/concrete/semantics.mlw
+++ b/src/concrete/semantics.mlw
@@ -33,12 +33,11 @@ module Behaviour
     notb under_condition
 
   type behaviour =
-    | BNormal  (** Normal behaviour *)
-    | BExit    (** Behaviour of exit instructions and instructions with return value false
-                   outside of conditions. Cought only from subshells *)
-    | BReturn  (** Return from function body. Cought by function call *)
-    | BFailure (** Uncatchable error behaviour without correspondance to Shell behaviour.
-                   Return value is undefined. Raised when crossing the boundary in while-loops. *)
+    | BNormal     (** Normal behaviour *)
+    | BExit       (** Behaviour of exit instructions and instructions with return value false
+                      outside of conditions. Cought only from subshells *)
+    | BReturn     (** Return from function body. Cought by function call *)
+    | BIncomplete (** Incompleteness of the semantics/interpreter  *)
 
   let function eq_behaviour bhv1 bhv2
     ensures { result <-> bhv1 = bhv2 }
@@ -46,7 +45,7 @@ module Behaviour
     | BNormal, BNormal
     | BExit, BExit 
     | BReturn, BReturn
-    | BFailure, BFailure ->  True
+    | BIncomplete, BIncomplete ->  True
     | _ -> False
     end
 
@@ -57,7 +56,7 @@ module Behaviour
   (*       under_condition = True \/ res = True *)
   (*     | BExit -> *)
   (*       under_condition = False /\ res = False *)
-  (*     | BReturn | BFailure -> *)
+  (*     | BReturn | BIncomplete -> *)
   (*       false *)
   (*   } *)
   (* = if andb (strict under_condition) (notb res) *)
@@ -411,7 +410,7 @@ module Semantics
         inp.under_condition = True \/ result = True
       | BExit ->
         inp.under_condition = False /\ result = False
-      | BReturn | BFailure ->
+      | BReturn | BIncomplete ->
         false
     }
   = if andb (strict inp.under_condition) (notb result)
@@ -482,15 +481,15 @@ module Semantics
     eval_instruction stk (cnf, inp, ctx, sta) (IShift bn) (sta', ctx', bhv)
 
   | eval_assignment: forall stk cnf inp ctx sta sta' id e s b.
-    eval_str_expr stk True (cnf, inp, ctx, sta) e (sta', Some (s, b)) ->
+    eval_str_expr stk True (cnf, inp, ctx, sta) e (sta', Result (s, b)) ->
     let ctx' = with_result b { ctx with var_env = ctx.var_env[id <- s] } in
     let bhv = behaviour inp ctx'.result in
     eval_instruction stk (cnf, inp, ctx, sta) (IAssignment id e) (sta', ctx', bhv)
 
-  | eval_assignment_failure: forall stk cnf inp ctx sta sta' id e.
-    eval_str_expr stk True (cnf, inp, ctx, sta) e (sta', None) ->
+  | eval_assignment_incomplete: forall stk cnf inp ctx sta sta' id e.
+    eval_str_expr stk True (cnf, inp, ctx, sta) e (sta', Incomplete) ->
     let ctx' = ctx in
-    eval_instruction stk (cnf, inp, ctx, sta) (IAssignment id e) (sta', ctx', BFailure)
+    eval_instruction stk (cnf, inp, ctx, sta) (IAssignment id e) (sta', ctx', BIncomplete)
   
   | eval_sequence: forall stk cnf inp sta sta1 sta2 ins1 ins2 ctx ctx1 ctx2 bhv2.
     eval_instruction stk (cnf, inp, ctx, sta) ins1 (sta1, ctx1, BNormal) ->
@@ -503,17 +502,17 @@ module Semantics
     eval_instruction stk (cnf, inp, ctx, sta) (ISequence ins1 ins2) (sta1, ctx1, bhv)
   
   | eval_subshell: forall stk cnf inp sta sta' ctx ctx'' ins bhv b.
-    bhv <> BFailure ->
+    bhv <> BIncomplete ->
     (* Subshells don’t increase the stack, OK? *)
     eval_instruction stk (cnf, inp, ctx, sta) ins (sta', {ctx'' with result = b}, bhv) ->
     let ctx' = with_result b ctx in
     let bhv' = behaviour inp ctx''.result in
     eval_instruction stk (cnf, inp, ctx, sta) (ISubshell ins) (sta', ctx', bhv')
 
-  | eval_subshell_failure: forall stk cnf inp sta sta' ctx ctx' ins.
-    eval_instruction stk (cnf, inp, ctx, sta) ins (sta', ctx', BFailure) ->
+  | eval_subshell_incomplete: forall stk cnf inp sta sta' ctx ctx' ins.
+    eval_instruction stk (cnf, inp, ctx, sta) ins (sta', ctx', BIncomplete) ->
     let ctx'' = with_result ctx'.result ctx in
-    eval_instruction stk (cnf, inp, ctx, sta) (ISubshell ins) (sta', ctx'', BFailure)
+    eval_instruction stk (cnf, inp, ctx, sta) (ISubshell ins) (sta', ctx'', BIncomplete)
 
   | eval_not: forall stk cnf inp ctx ctx' sta sta' ins bhv.
     (bhv = BNormal \/ bhv = BReturn) ->
@@ -522,7 +521,7 @@ module Semantics
     eval_instruction stk (cnf, inp, ctx, sta) (INot ins) (sta', ctx'', bhv)
 
   | eval_not_transmit: forall stk cnf inp ctx ctx' sta sta' ins bhv.
-    (bhv = BExit \/ bhv = BFailure) ->
+    (bhv = BExit \/ bhv = BIncomplete) ->
     eval_instruction stk (cnf, {inp with under_condition = True}, ctx, sta) ins (sta', ctx', bhv) ->
     eval_instruction stk (cnf, inp, ctx, sta) (INot ins) (sta', ctx', bhv)
   
@@ -550,7 +549,7 @@ module Semantics
   
   (** See NOTES[Pipe semantics] *)
   | eval_pipe: forall stk cnf inp ctx ctx1 ctx2 sta sta1 sta2 ins1 ins2 bhv1 bhv2.
-    bhv1 <> BFailure ->
+    bhv1 <> BIncomplete ->
     let sta' = {sta with stdout = Stdout.empty} in
     eval_instruction stk (cnf, inp, ctx, sta') ins1 (sta1, ctx1, bhv1) -> 
     let sta1' = {sta1 with stdout = sta.stdout; stdin = Stdout.to_stdin sta1.stdout} in
@@ -559,34 +558,34 @@ module Semantics
     let ctx' = with_result ctx2.result ctx in
     eval_instruction stk (cnf, inp, ctx, sta) (IPipe ins1 ins2) (sta2', ctx', bhv2)
 
-  | eval_pipe_failure: forall stk cnf inp ctx ctx1 sta sta1 ins1 ins2.
-    eval_instruction stk (cnf, inp, ctx, {sta with stdout=Stdout.empty}) ins1 (sta1, ctx1, BFailure) -> 
+  | eval_pipe_incomplete: forall stk cnf inp ctx ctx1 sta sta1 ins1 ins2.
+    eval_instruction stk (cnf, inp, ctx, {sta with stdout=Stdout.empty}) ins1 (sta1, ctx1, BIncomplete) -> 
     let sta1' = {sta1 with stdout = sta.stdout} in
     let ctx' = ctx in
-    eval_instruction stk (cnf, inp, ctx, sta) (IPipe ins1 ins2) (sta1', ctx', BFailure)
+    eval_instruction stk (cnf, inp, ctx, sta) (IPipe ins1 ins2) (sta1', ctx', BIncomplete)
   
-  | eval_call_utility_args_failure: forall stk cnf inp ctx sta sta' id es.
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', None) ->
-    eval_instruction stk (cnf, inp, ctx, sta) (ICallUtility id es) (sta', ctx, BFailure)
+  | eval_call_utility_args_incomplete: forall stk cnf inp ctx sta sta' id es.
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Incomplete) ->
+    eval_instruction stk (cnf, inp, ctx, sta) (ICallUtility id es) (sta', ctx, BIncomplete)
   
   | eval_call_utility: forall stk cnf inp ctx sta sta' sta'' id es ss b.
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Some ss) ->
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Result ss) ->
     (* Utilities don’t increase the stack, as long they do not generate instructions *)
     (sta'', Result b) = interp_utility sta' id ss ->
     let ctx' = with_result b ctx in
     let bhv = behaviour inp ctx'.result in
     eval_instruction stk (cnf, inp, ctx, sta) (ICallUtility id es) (sta'', ctx', bhv)
   
-  | eval_call_utility_failure: forall stk cnf inp ctx sta sta' sta'' id es ss.
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Some ss) ->
+  | eval_call_utility_incomplete: forall stk cnf inp ctx sta sta' sta'' id es ss.
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Result ss) ->
     (* Utilities don’t increase the stack, as long they do not generate instructions *)
     (sta'', Incomplete) = interp_utility sta' id ss ->
     let ctx' = ctx in
-    eval_instruction stk (cnf, inp, ctx, sta) (ICallUtility id es) (sta'', ctx', BFailure)
+    eval_instruction stk (cnf, inp, ctx, sta) (ICallUtility id es) (sta'', ctx', BIncomplete)
 
-  | eval_call_function_args_failure: forall stk cnf inp ctx sta sta1 id es.
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, None) ->
-    eval_instruction stk (cnf, inp, ctx, sta) (ICallFunction id es) (sta1, ctx, BFailure)
+  | eval_call_function_args_incomplete: forall stk cnf inp ctx sta sta1 id es.
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, Incomplete) ->
+    eval_instruction stk (cnf, inp, ctx, sta) (ICallFunction id es) (sta1, ctx, BIncomplete)
 
   | eval_call_function_not_found: forall stk cnf inp ctx sta sta' id es ss.
     eval_list_expr stk (cnf, inp, ctx, sta) es (sta', ss) ->
@@ -596,25 +595,25 @@ module Semantics
     eval_instruction stk (cnf, inp, ctx, sta) (ICallFunction id es) (sta', ctx', bhv)
 
   | eval_call_function_stack_limit: forall stk cnf inp ctx sta sta1 id es args ins.
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, Some args) ->
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, Result args) ->
     ctx.func_env id = Some ins ->
     match cnf.stack_size with Some n -> n = stk | None -> false end ->
     let ctx' = ctx in
-    eval_instruction stk (cnf, inp, ctx, sta) (ICallFunction id es) (sta1, ctx', BFailure)
+    eval_instruction stk (cnf, inp, ctx, sta) (ICallFunction id es) (sta1, ctx', BIncomplete)
 
-  | eval_call_function_failure: forall stk cnf inp ctx ctx2 sta sta1 sta2 id es args ins.
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, Some args) ->
+  | eval_call_function_incomplete: forall stk cnf inp ctx ctx2 sta sta1 sta2 id es args ins.
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, Result args) ->
     ctx.func_env id = Some ins ->
     let inp1 = { inp with argument0 = identifier_to_string id } in
     let ctx1 = { ctx with arguments = args } in
     match cnf.stack_size with Some n -> n <> stk | None -> true end ->
-    eval_instruction (stk+1) (cnf, inp1, ctx1, sta1) ins (sta2, ctx2, BFailure) ->
+    eval_instruction (stk+1) (cnf, inp1, ctx1, sta1) ins (sta2, ctx2, BIncomplete) ->
     let ctx' = with_result ctx2.result ctx in
-    eval_instruction stk (cnf, inp, ctx, sta) (ICallFunction id es) (sta2, ctx', BFailure)
+    eval_instruction stk (cnf, inp, ctx, sta) (ICallFunction id es) (sta2, ctx', BIncomplete)
 
   | eval_call_function: forall stk cnf inp ctx ctx2 sta sta1 sta2 id es args ins bhv.
-    bhv <> BFailure ->
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, Some args) ->
+    bhv <> BIncomplete ->
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, Result args) ->
     ctx.func_env id = Some ins ->
     match cnf.stack_size with Some n -> n <> stk | None -> true end ->
     let inp1 = { inp with argument0 = identifier_to_string id } in
@@ -624,12 +623,12 @@ module Semantics
     let ctx' = with_result ctx2.result ctx in
     eval_instruction stk (cnf, inp, ctx, sta) (ICallFunction id es) (sta2, ctx', bhv')
   
-  | eval_foreach_args_failure: forall stk cnf inp ctx sta sta' id es ins.
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', None) -> 
-    eval_instruction stk (cnf, inp, ctx, sta) (IForeach id es ins) (sta', ctx, BFailure)
+  | eval_foreach_args_incomplete: forall stk cnf inp ctx sta sta' id es ins.
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Incomplete) -> 
+    eval_instruction stk (cnf, inp, ctx, sta) (IForeach id es ins) (sta', ctx, BIncomplete)
   
   | eval_foreach: forall stk cnf inp ctx ctx' sta sta' sta'' id es ins ss bhv b.
-    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Some ss) -> 
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Result ss) -> 
     eval_foreach stk True (cnf, inp, ctx, sta') id ss ins (sta'', ctx', bhv) b ->
     let ctx'' = with_result b ctx' in
     eval_instruction stk (cnf, inp, ctx, sta) (IForeach id es ins) (sta'', ctx'', bhv)
@@ -664,7 +663,7 @@ module Semantics
     let sta' = sta in
     let ctx' = ctx in
     let n = ctr in
-    eval_while stk ctr b (cnf, inp, ctx, sta) ins1 ins2 (sta', ctx', BFailure) n b
+    eval_while stk ctr b (cnf, inp, ctx, sta) ins1 ins2 (sta', ctx', BIncomplete) n b
 
   (** Condition not normal *)
   | eval_while_abort_condition: forall stk cnf ctr b inp ctx ctx1 sta sta1 ins1 ins2 bhv1.
@@ -735,51 +734,49 @@ module Semantics
       boolean behaviour (only $(...) has a behaviour):
 
       $Bool (Config, Input, Context, State) i ⇓ (State, Option (String × Bool))$
-
-      A resulting None represents a failure in a subshell.
    *)
-  with eval_str_expr int bool (config, input, context, state) string_expression (state, option (string, bool))  =
+  with eval_str_expr int bool (config, input, context, state) string_expression (state_result (string, bool))  =
 
   | eval_str_literal: forall stk cnf b inp ctx sta str. 
-    let res = Some (str, b) in
+    let res = Result (str, b) in
     eval_str_expr stk b (cnf, inp, ctx, sta) (SLiteral str) (sta, res)
 
   | eval_str_variable: forall stk cnf b inp ctx sta id.
     let str = ctx.var_env[id] in
-    let res = Some (str, b) in
+    let res = Result (str, b) in
     eval_str_expr stk b (cnf, inp, ctx, sta) (SVariable id) (sta, res)
 
   | eval_str_arg: forall stk cnf b inp ctx sta n.
     let str = nth_argument (Cons inp.argument0 ctx.arguments) n.nat in
-    let res = Some (str, b) in
+    let res = Result (str, b) in
     eval_str_expr stk b (cnf, inp, ctx, sta) (SArgument n) (sta, res)
 
   | eval_str_subshell_failure: forall stk cnf b inp ctx ctx1 sta sta1 ins.
-    eval_instruction stk (cnf, inp, ctx, { sta with stdout = Stdout.empty }) ins (sta1, ctx1, BFailure) ->
+    eval_instruction stk (cnf, inp, ctx, { sta with stdout = Stdout.empty }) ins (sta1, ctx1, BIncomplete) ->
     let sta1' = { sta1 with stdout = sta.stdout } in
-    eval_str_expr stk b (cnf, inp, ctx, sta) (SSubshell ins) (sta1', None)
+    eval_str_expr stk b (cnf, inp, ctx, sta) (SSubshell ins) (sta1', Incomplete)
 
   | eval_str_subshell: forall stk cnf b inp ctx ctx1 sta sta1 ins bhv1.
-    bhv1 <> BFailure ->
+    bhv1 <> BIncomplete ->
     eval_instruction stk (cnf, inp, ctx, {sta with stdout = Stdout.empty}) ins (sta1, ctx1, bhv1) ->
     let str = Stdout.to_string sta1.stdout in
     let sta1' = { sta1 with stdout = sta.stdout } in
-    let res = Some (str, ctx1.result) in
+    let res = Result (str, ctx1.result) in
     eval_str_expr stk b (cnf, inp, ctx, sta) (SSubshell ins) (sta1', res)
 
   | eval_str_concat_failure1 : forall stk cnf b inp ctx sta sta1 e1 e2.
-    eval_str_expr stk b (cnf, inp, ctx, sta) e1 (sta1, None) ->
-    eval_str_expr stk b (cnf, inp, ctx, sta) (SConcat e1 e2) (sta1, None)
+    eval_str_expr stk b (cnf, inp, ctx, sta) e1 (sta1, Incomplete) ->
+    eval_str_expr stk b (cnf, inp, ctx, sta) (SConcat e1 e2) (sta1, Incomplete)
 
   | eval_str_concat_failure2 : forall stk cnf b b1 inp ctx sta sta1 sta2 e1 e2 str1.
-    eval_str_expr stk b (cnf, inp, ctx, sta) e1 (sta1, Some (str1, b1)) ->
-    eval_str_expr stk b1 (cnf, inp, ctx, sta1) e2 (sta2, None) ->
-    eval_str_expr stk b (cnf, inp, ctx, sta) (SConcat e1 e2) (sta2, None)
+    eval_str_expr stk b (cnf, inp, ctx, sta) e1 (sta1, Result (str1, b1)) ->
+    eval_str_expr stk b1 (cnf, inp, ctx, sta1) e2 (sta2, Incomplete) ->
+    eval_str_expr stk b (cnf, inp, ctx, sta) (SConcat e1 e2) (sta2, Incomplete)
 
   | eval_str_concat : forall stk cnf b b1 b2 inp ctx sta sta1 sta2 e1 e2 str1 str2.
-    eval_str_expr stk b (cnf, inp, ctx, sta) e1 (sta1, Some (str1, b1)) ->
-    eval_str_expr stk b1 (cnf, inp, ctx, sta1) e2 (sta2, Some (str2, b2)) ->
-    let res = Some (str1^str2, b2) in
+    eval_str_expr stk b (cnf, inp, ctx, sta) e1 (sta1, Result (str1, b1)) ->
+    eval_str_expr stk b1 (cnf, inp, ctx, sta1) e2 (sta2, Result (str2, b2)) ->
+    let res = Result (str1^str2, b2) in
     eval_str_expr stk b (cnf, inp, ctx, sta) (SConcat e1 e2) (sta2, res)
 
   (** Evaluation of expressions to a list of strings:
@@ -788,28 +785,28 @@ module Semantics
 
       A returning None represents a failure in a subshell in a string expression.
    *)
-  with eval_list_expr int (config, input, context, state) list_expression (state, option (list string)) =
+  with eval_list_expr int (config, input, context, state) list_expression (state_result (list string)) =
 
     | eval_list_expr_nil: forall stk cnf inp ctx sta.
-      eval_list_expr stk (cnf, inp, ctx, sta) Nil (sta, Some Nil)
+      eval_list_expr stk (cnf, inp, ctx, sta) Nil (sta, Result Nil)
 
     (* Incomplete in the head string expression *)
     | eval_list_expr_failure_head: forall stk cnf inp ctx sta sta1 se sp es.
-      eval_str_expr stk True (cnf, inp, ctx, sta) se (sta1, None) ->
-      eval_list_expr stk (cnf, inp, ctx, sta) (Cons (se, sp) es) (sta1, None)
+      eval_str_expr stk True (cnf, inp, ctx, sta) se (sta1, Incomplete) ->
+      eval_list_expr stk (cnf, inp, ctx, sta) (Cons (se, sp) es) (sta1, Incomplete)
 
     (* Incomplete in some tail string expression *)
     | eval_list_expr_failure_tail: forall stk cnf inp ctx sta sta1 sta2 se sp es s b1.
-      eval_str_expr stk True (cnf, inp, ctx, sta) se (sta1, Some (s, b1)) ->
-      eval_list_expr stk (cnf, inp, ctx, sta1) es (sta2, None) ->
-      eval_list_expr stk (cnf, inp, ctx, sta) (Cons (se, sp) es) (sta2, None)
+      eval_str_expr stk True (cnf, inp, ctx, sta) se (sta1, Result (s, b1)) ->
+      eval_list_expr stk (cnf, inp, ctx, sta1) es (sta2, Incomplete) ->
+      eval_list_expr stk (cnf, inp, ctx, sta) (Cons (se, sp) es) (sta2, Incomplete)
 
     | eval_list_expr_cons: forall stk cnf inp ctx sta sta1 sta2 se sp es s b1 l2.
-      eval_str_expr stk True (cnf, inp, ctx, sta) se (sta1, Some (s, b1)) ->
+      eval_str_expr stk True (cnf, inp, ctx, sta) se (sta1, Result (s, b1)) ->
       let l1 = split sp s in
-      eval_list_expr stk (cnf, inp, ctx, sta1) es (sta2, Some l2) ->
+      eval_list_expr stk (cnf, inp, ctx, sta1) es (sta2, Result l2) ->
       let l3 = l1 ++ l2 in
-      eval_list_expr stk (cnf, inp, ctx, sta) (Cons (se, sp) es) (sta2, Some l3)
+      eval_list_expr stk (cnf, inp, ctx, sta) (Cons (se, sp) es) (sta2, Result l3)
 
   (** Evaluation of a program. It outputs in a boolean value *)
   inductive eval_function_definitions func_env (list function_definition) func_env =
@@ -821,22 +818,22 @@ module Semantics
       eval_function_definitions e[id <- Some ins] defs e' ->
       eval_function_definitions e (Cons (id, ins) defs) e'
 
-  let rec lemma no_while_failure (ctr n:int) (cnf:config) (ins1 ins2:instruction)
+  let rec lemma no_while_incomplete (ctr n:int) (cnf:config) (ins1 ins2:instruction)
     requires { 0 <= ctr <= n }
     requires { cnf.loop_limit = None }
     variant { n - ctr }
     ensures {
       (forall stk inp ctx ctx' sta sta' bhv.
        eval_instruction stk (cnf, inp, ctx, sta) ins1 (sta', ctx', bhv) ->
-       bhv <> BFailure) ->
+       bhv <> BIncomplete) ->
       (forall stk inp ctx ctx' sta sta' bhv.
        eval_instruction stk (cnf, inp, ctx, sta) ins2 (sta', ctx', bhv) ->
-       bhv <> BFailure) ->
+       bhv <> BIncomplete) ->
       forall stk inp ctx ctx' sta sta' b b' bhv.
       eval_while stk ctr b (cnf, inp, ctx, sta) ins1 ins2 (sta', ctx', bhv) n b' ->
-      bhv <> BFailure
+      bhv <> BIncomplete
     }
-  = if n = ctr then () else no_while_failure (ctr+1) n cnf ins1 ins2
+  = if n = ctr then () else no_while_incomplete (ctr+1) n cnf ins1 ins2
 
   let rec interp_function_definitions (fenv:func_env) (defs:list function_definition)
     variant { defs }
@@ -847,21 +844,19 @@ module Semantics
       interp_function_definitions Env.(fenv[id <- Some instr])  defs'
     end
 
-  (** Evaluation of a CoLis program.
+  (** Evaluation of a CoLis program. *)
 
-      A return value of None represents a failure (e.g., boundary hit in while loop) in
-      the program. *)
   inductive eval_program (config, input, context, state) program (state, option bool) =
 
     | eval_program: forall cnf inp ctx fenv ctx' sta sta' pro bhv.
-      bhv <> BFailure ->
+      bhv <> BIncomplete ->
       eval_function_definitions ctx.func_env pro.function_definitions fenv ->
       eval_instruction 0 (cnf, inp, { ctx with func_env = fenv }, sta) pro.instruction (sta', ctx', bhv) ->
       eval_program (cnf, inp, ctx, sta) pro (sta', Some ctx'.result)
 
-    | eval_program_failure: forall cnf inp ctx ctx' sta sta' pro fenv.
+    | eval_program_incomplete: forall cnf inp ctx ctx' sta sta' pro fenv.
       eval_function_definitions ctx.func_env pro.function_definitions fenv ->
-      eval_instruction 0 (cnf, inp, { ctx with func_env = fenv }, sta) pro.instruction (sta', ctx', BFailure) ->
+      eval_instruction 0 (cnf, inp, { ctx with func_env = fenv }, sta) pro.instruction (sta', ctx', BIncomplete) ->
       eval_program (cnf, inp, ctx, sta) pro (sta', None)
 
   (* lemma eval_instruction_functional: forall ins[@induction] inp (\*out1 out2*\) ctx ctx1 ctx2 sta sta1 sta2 bhv1 bhv2. *)

--- a/src/concrete/semantics.mlw
+++ b/src/concrete/semantics.mlw
@@ -248,6 +248,13 @@ module AbstractState
     stdin: stdin;
     stdout: stdout;
   }
+
+  (** `Result` represents a valid result in CoLiS, and `Incomplete` represents an
+      incompleteness of the CoLiS interpreter. *)
+  type result 'a = Result 'a | Incomplete
+
+  (** Many functions return combinations of a state with a result. *)
+  type state_result 'a = (state, result 'a)
 end
 
 module Filesystem
@@ -424,8 +431,7 @@ module Semantics
 
       It acts upon the input and irreversable state, and returns a stdout, a behaviour
       (True/False), and another irreversable state, see also NOTES[Callees] *)
-  val function interp_utility state identifier (list string) :
-    (state, bool)
+  val function interp_utility state identifier (list string) : state_result bool
 
   axiom interp_utility_extends_output : forall sta sta' name args b.
     interp_utility {sta with stdout=Stdout.empty} name args = (sta', b) ->
@@ -566,10 +572,17 @@ module Semantics
   | eval_call_utility: forall stk cnf inp ctx sta sta' sta'' id es ss b.
     eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Some ss) ->
     (* Utilities don’t increase the stack, as long they do not generate instructions *)
-    (sta'', b) = interp_utility sta' id ss ->
+    (sta'', Result b) = interp_utility sta' id ss ->
     let ctx' = with_result b ctx in
     let bhv = behaviour inp ctx'.result in
     eval_instruction stk (cnf, inp, ctx, sta) (ICallUtility id es) (sta'', ctx', bhv)
+  
+  | eval_call_utility_failure: forall stk cnf inp ctx sta sta' sta'' id es ss.
+    eval_list_expr stk (cnf, inp, ctx, sta) es (sta', Some ss) ->
+    (* Utilities don’t increase the stack, as long they do not generate instructions *)
+    (sta'', Incomplete) = interp_utility sta' id ss ->
+    let ctx' = ctx in
+    eval_instruction stk (cnf, inp, ctx, sta) (ICallUtility id es) (sta'', ctx', BFailure)
 
   | eval_call_function_args_failure: forall stk cnf inp ctx sta sta1 id es.
     eval_list_expr stk (cnf, inp, ctx, sta) es (sta1, None) ->
@@ -780,12 +793,12 @@ module Semantics
     | eval_list_expr_nil: forall stk cnf inp ctx sta.
       eval_list_expr stk (cnf, inp, ctx, sta) Nil (sta, Some Nil)
 
-    (* Failure in the head string expression *)
+    (* Incomplete in the head string expression *)
     | eval_list_expr_failure_head: forall stk cnf inp ctx sta sta1 se sp es.
       eval_str_expr stk True (cnf, inp, ctx, sta) se (sta1, None) ->
       eval_list_expr stk (cnf, inp, ctx, sta) (Cons (se, sp) es) (sta1, None)
 
-    (* Failure in some tail string expression *)
+    (* Incomplete in some tail string expression *)
     | eval_list_expr_failure_tail: forall stk cnf inp ctx sta sta1 sta2 se sp es s b1.
       eval_str_expr stk True (cnf, inp, ctx, sta) se (sta1, Some (s, b1)) ->
       eval_list_expr stk (cnf, inp, ctx, sta1) es (sta2, None) ->

--- a/src/errors.ml
+++ b/src/errors.ml
@@ -1,6 +1,3 @@
 exception FileError of string
 exception ParseError of string * Lexing.position
 exception ConversionError of string
-
-exception UnsupportedUtility of string * string
-exception UnsupportedArgument of string * string * string

--- a/src/options.ml
+++ b/src/options.ml
@@ -1,4 +1,3 @@
-let fail_on_unknown_utilities = ref false
 let real_world = ref false
 let external_sources = ref ""
 let print_states_dir = ref ""

--- a/src/symbolic/symbolicInterpreter.mlw
+++ b/src/symbolic/symbolicInterpreter.mlw
@@ -154,14 +154,14 @@ module Results
     normal: set (sym_state 'a);
     exit: set (sym_state 'a);
     return_: set (sym_state 'a);
-    failure: set (sym_state 'a);
+    incomplete: set (sym_state 'a);
   }
 
   let constant empty = {
     normal = Fset.empty;
     exit = Fset.empty;
     return_ = Fset.empty;
-    failure = Fset.empty;
+    incomplete = Fset.empty;
   }
 
   (* let function results rs : set (sym_state 'a, behaviour) = *)
@@ -175,28 +175,28 @@ module Results
   let separate_normal res =
     res.normal, {res with normal = Fset.empty}
 
-  let separate_non_failure res =
-    union res.normal (union res.exit res.return_), res.failure
+  let separate_non_incomplete res =
+    union res.normal (union res.exit res.return_), res.incomplete
 
   let function all_states res =
-    union res.normal (union res.exit (union res.return_ res.failure))
+    union res.normal (union res.exit (union res.return_ res.incomplete))
 
-  let function failures (ctx:context) (stas:set state) : t unit =
+  let function incompletes (ctx:context) (stas:set state) : t unit =
     let aux sta = {state=sta; context=ctx; data=()} in
-    { empty with failure = Fset.map aux stas }
+    { empty with incomplete = Fset.map aux stas }
 
   let map f res = {
     normal  = Fset.map f res.normal;
     exit    = Fset.map f res.exit;
     return_ = Fset.map f res.return_;
-    failure = Fset.map f res.failure;
+    incomplete = Fset.map f res.incomplete;
   }
 
   let function union res1 res2 = {
     normal  = Fset.union res1.normal  res2.normal;
     exit    = Fset.union res1.exit    res2.exit;
     return_ = Fset.union res1.return_ res2.return_;
-    failure = Fset.union res1.failure res2.failure;
+    incomplete = Fset.union res1.incomplete res2.incomplete;
   }
 
   let function states bhv rs =
@@ -204,7 +204,7 @@ module Results
     | BNormal  -> rs.normal
     | BExit    -> rs.exit
     | BReturn  -> rs.return_
-    | BFailure -> rs.failure
+    | BIncomplete -> rs.incomplete
     end
 
   lemma states_union: forall bhv, rs1 rs2:t 'a.
@@ -221,7 +221,7 @@ module Results
   = {normal = Fset.filter (is_state_behaviour inp BNormal) stas;
      exit = Fset.filter (is_state_behaviour inp BExit) stas;
      return_ = Fset.empty;
-     failure = Fset.empty}
+     incomplete = Fset.empty}
 end
 
 module Interpreter
@@ -252,39 +252,22 @@ module Interpreter
 
   lemma list_mem_set_mem: forall x:'a, s. mem x s <-> Mem.mem x (Fset.to_list s)
 
-  let rec separate_failures' (sta_res: list (state_result 'a))
-    : (oks: list (state, 'a), failures: list state)
+  let rec separate_incompletes' (sta_res: list (state_result 'a))
+    : (oks: list (state, 'a), incompletes: list state)
     variant { sta_res }
-    (* ensures { *)
-    (*   forall sta x. Mem.mem (sta, x) results -> Mem.mem (sta, Some x) sta_opts *)
-    (* } *)
-    (* ensures { *)
-    (*   forall sta. Mem.mem sta failures -> Mem.mem (sta, None) sta_opts *)
-    (* } *)
-    (* ensures { *)
-    (*   sta_opts = *)
-    (*     Map.map (fun arg -> let sta, x = arg in sta, Some x) results *)
-    (*       ++ Map.map (fun sta -> sta, None) failures *)
-    (* } *)
   = match sta_res with
     | Nil -> Nil, Nil
     | Cons (sta, Result x) sta_res' ->
-      let oks, failures = separate_failures' sta_res' in
-      Cons (sta, x) oks, failures
+      let oks, incompletes = separate_incompletes' sta_res' in
+      Cons (sta, x) oks, incompletes
     | Cons (sta, Incomplete) sta_res' ->
-      let oks, failures = separate_failures' sta_res' in
-      oks, Cons sta failures
+      let oks, incompletes = separate_incompletes' sta_res' in
+      oks, Cons sta incompletes
     end
 
-  let separate_failures sta_res
-    (* returns { results, failures -> *)
-    (*   sta_opts = *)
-    (*     Fset.(union *)
-    (*       (map (fun arg -> let sta, x = arg in sta, Some x) results) *)
-    (*       (map (fun sta -> sta, None) failures)) *)
-    (* } *)
-  = let results, failures = separate_failures' (Fset.to_list sta_res) in
-    Fset.of_list results, Fset.of_list failures
+  let separate_incompletes sta_res
+  = let results, incompletes = separate_incompletes' (Fset.to_list sta_res) in
+    Fset.of_list results, Fset.of_list incompletes
 
   lemma set_mem_map: forall y: 'b, s: set 'a, f: 'a -> 'b.
     mem y (map f s) ->
@@ -371,12 +354,12 @@ module Interpreter
         normal = Fset.map flip_result res.normal;
         return_ = Fset.map flip_result res.return_;
         exit = res.exit;
-        failure = res.failure;
+        incomplete = res.incomplete;
       })
 
     | IAssignment var se ->
-      let str_stas, str_stas_failure =
-        separate_failures
+      let str_stas, str_stas_incomplete =
+        separate_incompletes
           (interp_str_expr stk True cnf inp ctx sta se)
       in
       let res =
@@ -393,8 +376,8 @@ module Interpreter
         Rs.inject inp
           (Fset.map for_str_sta str_stas)
       in
-      let res_failure = Rs.failures ctx str_stas_failure in
-      Rs.union res res_failure
+      let res_incomplete = Rs.incompletes ctx str_stas_incomplete in
+      Rs.union res res_incomplete
 
     | ISequence ins1 ins2 ->
       let res1_normal, res1_other =
@@ -405,8 +388,8 @@ module Interpreter
       Rs.union res2 res1_other
 
     | ISubshell ins ->
-      let stas, stas_failure =
-        Rs.separate_non_failure
+      let stas, stas_incomplete =
+        Rs.separate_non_incomplete
           (interp_instr stk cnf inp ctx sta ins)
       in
       let stas' =
@@ -417,7 +400,7 @@ module Interpreter
         map aux stas
       in
       Rs.(union (inject inp stas')
-            {empty with failure = stas_failure})
+            {empty with incomplete = stas_incomplete})
 
     | INoOutput ins ->
       Rs.map (reset_output sta)
@@ -439,8 +422,8 @@ module Interpreter
       Rs.union res2 res1_other
 
     | ICallUtility id le ->
-      let res, res_failures =
-        separate_failures
+      let res, res_incompletes =
+        separate_incompletes
           (interp_list_expr stk cnf inp ctx sta le)
       in
       let res' =
@@ -449,7 +432,7 @@ module Interpreter
           interp_utility id ctx.var_env args sta' (*FIXME: export?*)
         in
         let oks: set (state, bool), fls: set state =
-          separate_failures
+          separate_incompletes
             (bind call_utility res)
         in
         let for_ok (arg:(state, bool)) : sym_state unit =
@@ -459,16 +442,16 @@ module Interpreter
         in
         let oks' = map for_ok oks in
         Rs.(union (inject inp oks')
-              (failures ctx fls))
+              (incompletes ctx fls))
       in
-      let res_failures' =
-        Rs.failures ctx res_failures
+      let res_incompletes' =
+        Rs.incompletes ctx res_incompletes
       in
-      Rs.union res' res_failures'
+      Rs.union res' res_incompletes'
 
     | ICallFunction id le ->
-      let arg_res, arg_res_failures =
-        separate_failures
+      let arg_res, arg_res_incompletes =
+        separate_incompletes
           (interp_list_expr stk cnf inp ctx sta le)
       in
       let res =
@@ -479,7 +462,7 @@ module Interpreter
               let sta', _ = arg in
               {state=sta'; context=ctx; data=()}
             in
-            Rs.({empty with failure = Fset.map aux arg_res})
+            Rs.({empty with incomplete = Fset.map aux arg_res})
           else
             let res2 =
               let rec for_arg_res (res:list (state, list string)) : Rs.t unit variant { res } =
@@ -509,8 +492,8 @@ module Interpreter
             Rs.inject inp (Fset.map sym_state arg_res)
         end
       in
-      let res_failures = Rs.failures ctx arg_res_failures in
-      Rs.union res res_failures
+      let res_incompletes = Rs.incompletes ctx arg_res_incompletes in
+      Rs.union res res_incompletes
 
     | IShift bn ->
       match shift_arguments (option_get (mk_nat 1) bn).nat ctx.arguments with
@@ -525,8 +508,8 @@ module Interpreter
       end
 
     | IForeach id le ins ->
-      let lst_res, lst_res_failures =
-        separate_failures
+      let lst_res, lst_res_incompletes =
+        separate_incompletes
           (interp_list_expr stk cnf inp ctx sta le)
       in
       (* Run interpretation of foreach in one state *)
@@ -577,7 +560,7 @@ module Interpreter
       Rs.(union
            (map set_result
              (loop_res (Fset.to_list lst_res)))
-           (Rs.failures ctx lst_res_failures))
+           (Rs.incompletes ctx lst_res_incompletes))
 
     | IWhile ins1 ins2 ->
       let loop_limit = match cnf.loop_limit with Some n -> n | None -> absurd end in
@@ -586,7 +569,7 @@ module Interpreter
         requires { ctr <= get_some cnf.loop_limit }
       = if ctr = loop_limit then
           Rs.(map (with_data ())
-                {empty with failure = stas})
+                {empty with incomplete = stas})
         else
           let res1_normal, res1_abort =
             Rs.separate_normal
@@ -611,9 +594,9 @@ module Interpreter
       interp_while 0 (Fset.singleton ({state=sta; context=ctx; data=True}))
 
     | IPipe ins1 ins2 ->
-      let stas1, stas1_failure =
+      let stas1, stas1_incomplete =
         let sta' = {sta with stdout = Stdout.empty} in
-        Rs.separate_non_failure
+        Rs.separate_non_incomplete
           (interp_instr stk cnf inp ctx sta' ins1)
       in
       let res2 =
@@ -637,7 +620,7 @@ module Interpreter
       in
       Rs.(union
             (map revise res2)
-            {empty with failure = stas1_failure})
+            {empty with incomplete = stas1_incomplete})
 
     | IExit code ->
       let r =
@@ -716,20 +699,20 @@ module Interpreter
       let str = nth_argument (Cons inp.argument0 ctx.arguments) n.nat in
       singleton (sta, Result (str, b))
     | SSubshell ins ->
-      let res, stas_failures =
+      let res, stas_incompletes =
         let sta' = {sta with stdout=Stdout.empty} in
-        Rs.separate_non_failure
+        Rs.separate_non_incomplete
           (interp_instr stk cnf inp ctx sta' ins)
       in
-      let for_non_failure (sta1:sym_state unit) =
+      let for_non_incomplete (sta1:sym_state unit) =
         let str = Stdout.to_string sta1.state.stdout in
         let sta1' = {sta1.state with stdout=sta.stdout} in
         let b' = sta1.context.result in
         sta1', Result  (str, b')
       in
       Fset.(union
-        (map for_non_failure res)
-        (map (fun sta1 -> sta1.state, Incomplete) stas_failures))
+        (map for_non_incomplete res)
+        (map (fun sta1 -> sta1.state, Incomplete) stas_incompletes))
     | SConcat se1 se2 ->
       let res1 = interp_str_expr stk b cnf inp ctx sta se1 in
       let rec for_res1 (res1: list (state_result (string, bool))) : set (state_result (string, bool))
@@ -773,11 +756,11 @@ module Interpreter
     | Nil ->
       singleton (sta, Result Nil)
     | Cons (se, sp) le' ->
-      let str_res1, str_res1_failures =
-        separate_failures
+      let str_res1, str_res1_incompletes =
+        separate_incompletes
           (interp_str_expr stk True cnf inp ctx sta se)
       in
-      let lst_res1 = (* Non-failure string list results *)
+      let lst_res1 = (* Non-incomplete string list results *)
         let aux arg =
           let sta, (str, _:bool) = arg in
           sta, Sem.split sp str
@@ -789,8 +772,8 @@ module Interpreter
       = match res1 with
         | Nil -> empty
         | Cons (sta1, l1) res1' ->
-          let lst_res2, lst_res2_failures =
-            separate_failures
+          let lst_res2, lst_res2_incompletes =
+            separate_incompletes
               (interp_list_expr stk cnf inp ctx sta1 le')
           in
           let lst_res12 =
@@ -802,13 +785,13 @@ module Interpreter
           in
           union lst_res12
             (union
-              (map (fun sta -> sta, Incomplete) lst_res2_failures)
+              (map (fun sta -> sta, Incomplete) lst_res2_incompletes)
               (for_lst_res1 res1'))
         end
       in
       union
         (for_lst_res1 (Fset.to_list lst_res1))
-        (map (fun sta -> sta, Incomplete) str_res1_failures)
+        (map (fun sta -> sta, Incomplete) str_res1_incompletes)
     end
 
   let rec interp_function_definitions (fenv:func_env) (defs:list function_definition)
@@ -827,14 +810,14 @@ module Interpreter
   let interp_program loop_limit stack_size inp ctx sta pro : (set state, set state, set state)
     requires { 0 <= loop_limit }
     requires { 0 <= stack_size }
-  = let stas, stas_failure =
+  = let stas, stas_incomplete =
       let fenv = interp_function_definitions ctx.func_env pro.function_definitions in
       let ctx' = {ctx with func_env = fenv} in
       let cnf = { loop_limit = Some loop_limit; stack_size = Some stack_size } in
-      Rs.separate_non_failure
+      Rs.separate_non_incomplete
         (interp_instr 0 cnf inp ctx' sta pro.instruction)
     in
     (only_states_with_result True stas,
      only_states_with_result False stas,
-     Fset.map (fun sta -> sta.state) stas_failure)
+     Fset.map (fun sta -> sta.state) stas_incomplete)
 end

--- a/src/symbolic/symbolicInterpreter.mlw
+++ b/src/symbolic/symbolicInterpreter.mlw
@@ -248,13 +248,13 @@ module Interpreter
   use Results as Rs
 
   (* Implemented in OCaml *)
-  val function interp_utility identifier var_env (list string) state : set (state, bool)
+  val function interp_utility identifier var_env (list string) state : set (state, result bool)
 
   lemma list_mem_set_mem: forall x:'a, s. mem x s <-> Mem.mem x (Fset.to_list s)
 
-  let rec separate_options' (sta_opts: list (state, option 'a))
-    : (results: list (state, 'a), failures: list state)
-    variant { sta_opts }
+  let rec separate_failures' (sta_res: list (state_result 'a))
+    : (oks: list (state, 'a), failures: list state)
+    variant { sta_res }
     (* ensures { *)
     (*   forall sta x. Mem.mem (sta, x) results -> Mem.mem (sta, Some x) sta_opts *)
     (* } *)
@@ -266,24 +266,24 @@ module Interpreter
     (*     Map.map (fun arg -> let sta, x = arg in sta, Some x) results *)
     (*       ++ Map.map (fun sta -> sta, None) failures *)
     (* } *)
-  = match sta_opts with
+  = match sta_res with
     | Nil -> Nil, Nil
-    | Cons (sta, Some x) sta_opts' ->
-      let results, failures = separate_options' sta_opts' in
-      Cons (sta, x) results, failures
-    | Cons (sta, None) sta_opts' ->
-      let results, failures = separate_options' sta_opts' in
-      results, Cons sta failures
+    | Cons (sta, Result x) sta_res' ->
+      let oks, failures = separate_failures' sta_res' in
+      Cons (sta, x) oks, failures
+    | Cons (sta, Incomplete) sta_res' ->
+      let oks, failures = separate_failures' sta_res' in
+      oks, Cons sta failures
     end
 
-  let separate_options sta_opts
+  let separate_failures sta_res
     (* returns { results, failures -> *)
     (*   sta_opts = *)
     (*     Fset.(union *)
     (*       (map (fun arg -> let sta, x = arg in sta, Some x) results) *)
     (*       (map (fun sta -> sta, None) failures)) *)
     (* } *)
-  = let results, failures = separate_options' (Fset.to_list sta_opts) in
+  = let results, failures = separate_failures' (Fset.to_list sta_res) in
     Fset.of_list results, Fset.of_list failures
 
   lemma set_mem_map: forall y: 'b, s: set 'a, f: 'a -> 'b.
@@ -376,7 +376,7 @@ module Interpreter
 
     | IAssignment var se ->
       let str_stas, str_stas_failure =
-        separate_options
+        separate_failures
           (interp_str_expr stk True cnf inp ctx sta se)
       in
       let res =
@@ -440,7 +440,7 @@ module Interpreter
 
     | ICallUtility id le ->
       let res, res_failures =
-        separate_options
+        separate_failures
           (interp_list_expr stk cnf inp ctx sta le)
       in
       let res' =
@@ -448,14 +448,18 @@ module Interpreter
           let sta', args = arg in
           interp_utility id ctx.var_env args sta' (*FIXME: export?*)
         in
-        let for_call_result arg =
+        let oks: set (state, bool), fls: set state =
+          separate_failures
+            (bind call_utility res)
+        in
+        let for_ok (arg:(state, bool)) : sym_state unit =
           let sta'', b = arg in
           let ctx' = with_result b ctx in
           {state=sta''; context=ctx'; data=()}
         in
-        Rs.inject inp
-          (map for_call_result
-             (bind call_utility res))
+        let oks' = map for_ok oks in
+        Rs.(union (inject inp oks')
+              (failures ctx fls))
       in
       let res_failures' =
         Rs.failures ctx res_failures
@@ -464,7 +468,7 @@ module Interpreter
 
     | ICallFunction id le ->
       let arg_res, arg_res_failures =
-        separate_options
+        separate_failures
           (interp_list_expr stk cnf inp ctx sta le)
       in
       let res =
@@ -522,7 +526,7 @@ module Interpreter
 
     | IForeach id le ins ->
       let lst_res, lst_res_failures =
-        separate_options
+        separate_failures
           (interp_list_expr stk cnf inp ctx sta le)
       in
       (* Run interpretation of foreach in one state *)
@@ -689,7 +693,7 @@ module Interpreter
     aux (Fset.to_list stas)
 
   with interp_str_expr (stk:int) (b:bool) (cnf:config) (inp:input) (ctx:context) (sta:state) (se:string_expression)
-    : set (state, option (string, bool))
+    : set (state_result (string, bool))
     requires { cnf.loop_limit <> None /\ cnf.stack_size <> None }
     requires { stk <= get_some cnf.stack_size }
     variant { get_some cnf.stack_size - stk, get_some cnf.loop_limit + 1, skel_string_expr se, -1 }
@@ -701,16 +705,16 @@ module Interpreter
     (* } *)
   = match se with
     | SLiteral str ->
-      singleton (sta, Some (str, b))
+      singleton (sta, Result (str, b))
     | SVariable var ->
       let str =
         try Env.get ctx.var_env var
         with Env.Not_found -> String.empty end
       in
-      singleton (sta, Some (str, b))
+      singleton (sta, Result (str, b))
     | SArgument n ->
       let str = nth_argument (Cons inp.argument0 ctx.arguments) n.nat in
-      singleton (sta, Some (str, b))
+      singleton (sta, Result (str, b))
     | SSubshell ins ->
       let res, stas_failures =
         let sta' = {sta with stdout=Stdout.empty} in
@@ -721,29 +725,29 @@ module Interpreter
         let str = Stdout.to_string sta1.state.stdout in
         let sta1' = {sta1.state with stdout=sta.stdout} in
         let b' = sta1.context.result in
-        sta1', Some  (str, b')
+        sta1', Result  (str, b')
       in
       Fset.(union
         (map for_non_failure res)
-        (map (fun sta1 -> sta1.state, None) stas_failures))
+        (map (fun sta1 -> sta1.state, Incomplete) stas_failures))
     | SConcat se1 se2 ->
       let res1 = interp_str_expr stk b cnf inp ctx sta se1 in
-      let rec for_res1 (res1: list (state, option (string, bool))) : set (state, option (string, bool))
+      let rec for_res1 (res1: list (state_result (string, bool))) : set (state_result (string, bool))
         variant { res1 }
       = match res1 with
         | Nil ->
           empty
-        | Cons (sta1, None) res1' ->
-          Fset.add (sta1, None)
+        | Cons (sta1, Incomplete) res1' ->
+          Fset.add (sta1, Incomplete)
             (for_res1 res1')
-        | Cons (sta1, Some (str1, b1)) res1' ->
+        | Cons (sta1, Result (str1, b1)) res1' ->
           let stas = interp_str_expr stk b1 cnf inp ctx sta1 se2 in
           let concat arg =
             match arg with
-            | sta2, None ->
-              sta2, None
-            | sta2, Some (str2, b2) ->
-              sta2, Some (str1^str2, b2)
+            | sta2, Incomplete ->
+              sta2, Incomplete
+            | sta2, Result (str2, b2) ->
+              sta2, Result (str1^str2, b2)
             end
           in
           Fset.union
@@ -755,7 +759,7 @@ module Interpreter
     end
 
   with interp_list_expr (stk:int) (cnf:config) (inp:input) (ctx:context) (sta:state) (le:list_expression)
-    : set (state, option (list string))
+    : set (state_result (list string))
     requires { cnf.loop_limit <> None /\ cnf.stack_size <> None }
     requires { stk <= get_some cnf.stack_size }
     variant { get_some cnf.stack_size - stk, get_some cnf.loop_limit + 1, skel_list_expr le, -1 }
@@ -767,10 +771,10 @@ module Interpreter
     (* } *)
   = match le with
     | Nil ->
-      singleton (sta, Some Nil)
+      singleton (sta, Result Nil)
     | Cons (se, sp) le' ->
       let str_res1, str_res1_failures =
-        separate_options
+        separate_failures
           (interp_str_expr stk True cnf inp ctx sta se)
       in
       let lst_res1 = (* Non-failure string list results *)
@@ -780,31 +784,31 @@ module Interpreter
         in
         map aux str_res1
       in
-      let rec for_lst_res1 (res1: list (state, list string)) : set (state, option (list string))
+      let rec for_lst_res1 (res1: list (state, list string)) : set (state_result (list string))
         variant { res1 }
       = match res1 with
         | Nil -> empty
         | Cons (sta1, l1) res1' ->
           let lst_res2, lst_res2_failures =
-            separate_options
+            separate_failures
               (interp_list_expr stk cnf inp ctx sta1 le')
           in
           let lst_res12 =
             let concat arg =
               let sta2, l2 = arg in
-              sta2, Some (l1++l2)
+              sta2, Result (l1++l2)
             in
             Fset.map concat lst_res2
           in
           union lst_res12
             (union
-              (map (fun sta -> sta, None) lst_res2_failures)
+              (map (fun sta -> sta, Incomplete) lst_res2_failures)
               (for_lst_res1 res1'))
         end
       in
       union
         (for_lst_res1 (Fset.to_list lst_res1))
-        (map (fun sta -> sta, None) str_res1_failures)
+        (map (fun sta -> sta, Incomplete) str_res1_failures)
     end
 
   let rec interp_function_definitions (fenv:func_env) (defs:list function_definition)

--- a/src/symbolic/utilitiesSpecification.ml
+++ b/src/symbolic/utilitiesSpecification.ml
@@ -3,48 +3,39 @@ open SymbolicInterpreter__Filesystem
 open SymbolicInterpreter__State
 open Semantics__Buffers
 
-type utility = state -> (state * bool) list
+type utility = state -> (bool state_result) list
 
 let print_line msg state =
   let open Semantics__Buffers in
   let stdout = Stdout.(output msg state.stdout |> newline) in
   {state with stdout}
 
-let print_utility_trace msg state =
+let print_utility_descr result msg state =
   if String.equal msg "" then
     state
   else
-    let msg = "[UTL] "^msg in
-    print_line msg state
-
-let print_error msg state =
-  match msg with
-  | Some msg ->
-    let msg = "[ERR] "^msg in
-    print_line msg state
-  | None ->
-    state
+    let prefix = match result with
+      | Result true ->  "[DBG] "
+      | Result false -> "[ERR] "
+      | Incomplete ->   "[INCOMPLETE] "
+    in
+    print_line (prefix^msg) state
 
 type case = {
-  result : bool;
+  result : bool result;
   spec : Clause.t;
   descr : string;
   stdout : Stdout.t ;
-  error_message: string option;
 }
 
 let success_case ~descr ?(stdout=Stdout.empty) spec =
-  { result = true ; error_message = None ; stdout ; descr; spec }
+  { result = Result true ; stdout ; descr; spec }
 
-let error_case ~descr ?(stdout=Stdout.empty) ?error_message spec =
-  { result = false ; error_message ; stdout ; descr ; spec }
+let error_case ~descr ?(stdout=Stdout.empty) spec =
+  { result = Result false ; stdout ; descr ; spec }
 
-let failure ?error_message () =
-  [{ result = false ;
-     descr = "" ;
-     stdout = Stdout.empty ;
-     error_message ;
-     spec = Clause.true_ }]
+let failure_case ~descr ?(stdout=Stdout.empty) spec =
+  { result = Incomplete ; stdout ; descr ; spec }
 
 let quantify_over_intermediate_root state conj =
   if BatOption.eq ~eq:Var.equal state.filesystem.root0 (Some state.filesystem.root) then
@@ -61,12 +52,11 @@ let apply_clause_to_state state case root clause =
   let filesystem = {state.filesystem with clause; root} in
   let state' =
     { state with filesystem }
-    |> print_error case.error_message
-    |> print_utility_trace case.descr
+    |> print_utility_descr case.result case.descr
   in
   state', case.result
 
-let apply_case_to_state state root case : (state * bool) list =
+let apply_case_to_state state root case =
   let state = apply_output_to_state state case.stdout in
   (* Add the case specification to the current clause *)
   Clause.add_to_sat_conj case.spec state.filesystem.clause
@@ -76,8 +66,7 @@ let apply_case_to_state state root case : (state * bool) list =
 
 type specifications = cwd:Path.t -> root:Var.t -> root':Var.t -> case list
 
-let under_specifications : specifications -> state -> (state * bool) list =
-  fun spec state ->
-    let new_root = Var.fresh ~hint:(Var.hint state.filesystem.root) () in
-    let cases = spec ~cwd:state.filesystem.cwd ~root:state.filesystem.root ~root':new_root in
-    List.map (apply_case_to_state state new_root) cases |> List.flatten
+let under_specifications spec state =
+  let new_root = Var.fresh ~hint:(Var.hint state.filesystem.root) () in
+  let cases = spec ~cwd:state.filesystem.cwd ~root:state.filesystem.root ~root':new_root in
+  List.map (apply_case_to_state state new_root) cases |> List.flatten

--- a/src/symbolic/utilitiesSpecification.mli
+++ b/src/symbolic/utilitiesSpecification.mli
@@ -1,10 +1,10 @@
 open Constraints
-open SymbolicInterpreter__State
 open Semantics__Buffers
+open SymbolicInterpreter__State
 
 (** A utility transforms a symbolic states into a list of symbol states with boolean
    results *)
-type utility = state -> (state * bool) list
+type utility = state -> (bool state_result) list
 
 (** A case in the specification is either a success or an error *)
 type case
@@ -13,10 +13,10 @@ type case
 val success_case: descr:string -> ?stdout:Stdout.t -> Clause.t -> case
 
 (** An error case **)
-val error_case: descr:string -> ?stdout:Stdout.t -> ?error_message:string -> Clause.t -> case
+val error_case: descr:string -> ?stdout:Stdout.t -> Clause.t -> case
 
-(** A singleton error case with optional error message *)
-val failure: ?error_message:string -> unit -> case list
+(** A failure case **)
+val failure_case: descr:string -> ?stdout:Stdout.t -> Clause.t -> case
 
 (** The specifications of a utility are a list of cases that depend on the current working
    directory, the old root variable, and a new root variable *)


### PR DESCRIPTION
This PR

- introduces a type to capture a state with a result if the semantics/interpreter covered the execution, or without result for incompletnesses of the interpreters
```
type result 'a = Result 'a | Incomplete
type state_result 'a = (state, result 'a)
```
- uses the incompletness behaviour as a result for known utiltiies and arguments that are _not implemented_. Incompleteness was previously only used for stack overflow or loop limits. This approach allows identifying errorneous behaviour in presence of incomplete behaviour. For example
```shell
$ cat test.sh
if mkdir /abc; then
  admin # Not implemented
else
  foo # Error
fi
$ ./bin/colis --run-symbolic test.sh; echo -- $?
* Initial state
- id: init-0
  root: r₁
  cwd: /
  clause: dir(r₁)
  
* Error states
- id: error-1
  root: r₁₄
  cwd: /
  clause: ∃ ?₁₀⋅ r₁ = r₁₄ ∧ r₁[abc]?₁₀ ∧ dir(r₁)
  stdout: |
    [ERR] mkdir /abc: target already exists
    [ERR] Utility foo not found
    
* Incomplete symbolic execution
- id: notcovered-1
  root: r₁₆
  cwd: /
  clause: ∃ abc₆⋅ r₁₆[abc]abc₆ ∧ r₁[abc]↑ ∧ dir(r₁) ∧ dir(abc₆) ∧ dir(r₁₆) ∧ abc₆[∅] ∧ r₁ ~{abc} r₁₆
  stdout: |
    [DBG] mkdir /abc: create directory
    [INCOMPLETE] Utility admin not implemented
    
* Summary

- Success cases: 0
- Error cases: 1
- Incomplete symbolic execution: 1

-- 1
```
- The difference between an error (`foo`) and an incompletness (`admin`) is made by a list of utilities in `Utilities` (copied from https://pubs.opengroup.org/onlinepubs/9699919799/).
- rename behaviour `BFailure` into `BIncomplete`

This required comprehensive changes to `SymbolicSpecifications` and `SymbolicUtilities`, and will influence future changes for #65 #69. But I think it’s the right @claudemarche @Niols, what do you think? We can discuss on Wednesday.

Fixes #70 