### PR TITLE
Fix clause in SymbolicUtility.failure

### DIFF
--- a/src/symbolic/cp.ml
+++ b/src/symbolic/cp.ml
@@ -15,16 +15,16 @@ let interp_cp2 ctx ~todir ~isrec src dst : utility =
   let qdst = Path.from_string dst in
   match Path.split_last qsrc, Path.split_last qdst with
   | (None, _) ->
-     failure ~error_message:"cp: invalid source path ''" ()
+     failure ~error_message:"cp: invalid source path ''" ~root ~root'
   | (_, None) ->
-     failure ~error_message:"cp: invalid destination path ''" ()
+     failure ~error_message:"cp: invalid destination path ''" ~root ~root'
   | (Some (_, (Here|Up)), _) ->
      (* TODO: "For each source_file, the following steps ...
         source file is dot or dot-dot, cp should do nothing
         with source file and go to any remaining file" *)
-     failure ~error_message:"cp: source path ends in . or .." ()
+     failure ~error_message:"cp: source path ends in . or .." ~root ~root'
   | (_, Some (_, (Here|Up))) -> (* Unreachable or error path *)
-     failure ~error_message:"cp: destination path ends in . or .." ()
+     failure ~error_message:"cp: destination path ends in . or .." ~root ~root'
   | (Some (_qs, Down fs), Some (qd, efd)) ->
      let stripdst = Path.strip_trailing_slashes dst in
      let newdst = String.concat "/" [stripdst; (Feat.to_string fs)] in

--- a/src/symbolic/symbolicUtility.ml
+++ b/src/symbolic/symbolicUtility.ml
@@ -111,12 +111,12 @@ let success_case ~descr ?(stdout=Stdout.empty) spec =
 let error_case ~descr ?(stdout=Stdout.empty) ?error_message spec =
   { result = false ; error_message ; stdout ; descr ; spec }
 
-let failure ?error_message () =
+let failure ?error_message ~root ~root' =
   [{ result = false ;
      descr = "" ;
      stdout = Stdout.empty ;
      error_message ;
-     spec = Clause.true_ }]
+     spec = Clause.eq root root' }]
 
 let quantify_over_intermediate_root fs conj =
   if BatOption.eq ~eq:Var.equal fs.SymbolicInterpreter__Filesystem.root0 (Some fs.root) then

--- a/src/symbolic/symbolicUtility.mli
+++ b/src/symbolic/symbolicUtility.mli
@@ -43,7 +43,7 @@ type specifications = root:Var.t -> root':Var.t -> case list
    Var.t -> Clause.t], which isn't currently possible. *)
 
 (** A singleton error case with optional error message *)
-val failure: ?error_message:string -> unit -> case list
+val failure: ?error_message:string -> root:Var.t -> root':Var.t -> case list
 
 (** Use specifications to define a utility *)
 val under_specifications : specifications -> utility

--- a/src/symbolic/utilities/mkdir.ml
+++ b/src/symbolic/utilities/mkdir.ml
@@ -10,9 +10,9 @@ let interp_mkdir1 cwd path_str =
   let p = Path.from_string path_str in
   match Path.split_last p with
   | None ->
-    failure ~error_message:"mkdir: cannot create directory ''" ()
+    failure ~error_message:"mkdir: cannot create directory ''" ~root ~root'
   | Some (_q, (Here|Up)) ->
-    failure ~error_message:"mkdir: file exists" () (* CHECK *)
+    failure ~error_message:"mkdir: file exists" ~root ~root' (* CHECK *)
   | Some (q, Down f) ->
     let hintx = last_comp_as_hint ~root q in
     let hinty = Feat.to_string f in [

--- a/src/symbolic/utilities/mv.ml
+++ b/src/symbolic/utilities/mv.ml
@@ -14,11 +14,11 @@ let interp_rename ctx src dstpath : utility =
     let qdst = Path.from_string dstpath in
     match Path.split_last qsrc, Path.split_last qdst with
     | (None, _) ->
-       failure ~error_message:"mv: invalid source path ''" ()
+       failure ~error_message:"mv: invalid source path ''" ~root ~root'
     | (_, None) ->
-       failure ~error_message:"mv: invalid destination path ''" ()
+       failure ~error_message:"mv: invalid destination path ''" ~root ~root'
     | (Some (_, (Here|Up)), _) | (_, Some(_, (Here|Up))) ->
-       failure ~error_message:"mv: paths end in . or .." ()
+       failure ~error_message:"mv: paths end in . or .." ~root ~root'
     | (Some (qs, Down fs), Some (qd, Down fd)) ->
        let hintxs = last_comp_as_hint ~root qs in
        let hintys = last_comp_as_hint ~root qsrc in

--- a/src/symbolic/utilities/rm.ml
+++ b/src/symbolic/utilities/rm.ml
@@ -12,9 +12,9 @@ let interp1 cwd arg : utility =
   (* FIXME: Here, I reuse the same programming scheme as in mkdir. *)
   (* FIXME: Shouldn't we factorize it in a combinator?             *)
   | None ->
-    failure ~error_message:"rm: invalid path ''" ()
+    failure ~error_message:"rm: invalid path ''" ~root ~root'
   | Some (_q, (Here|Up)) ->
-    failure ~error_message:"rm: cannot remove .. or ." ()
+    failure ~error_message:"rm: cannot remove .. or ." ~root ~root'
   | Some (q, Down f) ->
     let hintx = last_comp_as_hint ~root q in
     let hinty = Feat.to_string f in [
@@ -45,9 +45,9 @@ let interp1_r cwd arg : utility =
   (* FIXME: Here, I reuse the same programming scheme as in mkdir. *)
   (* FIXME: Shouldn't we factorize it in a combinator?             *)
   | None ->
-    failure ~error_message:"rm: invalid path ''" ()
+    failure ~error_message:"rm: invalid path ''" ~root ~root'
   | Some (_q, (Here|Up)) ->
-    failure ~error_message:"rm: cannot remove .. or ." ()
+    failure ~error_message:"rm: cannot remove .. or ." ~root ~root'
   | Some (q, Down f) ->
     let hintx = last_comp_as_hint ~root q in
     let hinty = Feat.to_string f in [

--- a/src/symbolic/utilities/touch.ml
+++ b/src/symbolic/utilities/touch.ml
@@ -12,7 +12,7 @@ let interp_touch1 cwd path_str : utility =
   let p = Path.from_string path_str in
   match Path.split_last p with
   | None -> (* `touch ''` *)
-    failure ~error_message:"cannot touch '': No such file or directory" ()
+    failure ~error_message:"cannot touch '': No such file or directory" ~root ~root'
   | Some (q, (Up | Here)) ->
     let hint = last_comp_as_hint ~root p in [
       success_case


### PR DESCRIPTION
The `clause` in function `SymbolicUtility.failure` was just `true` and this PR corrects it to be `r = r'`.