### PR TITLE
Shadow aware printing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ services:
 ## are in fact tags for the ocaml/opam2 Docker image that we pull.
 
 env:
+  - TAG=4.09
+  - TAG=4.08
   - TAG=4.07
   - TAG=4.06
   - TAG=4.05

--- a/src/constraints/common/var.mli
+++ b/src/constraints/common/var.mli
@@ -1,4 +1,5 @@
 type t
+[@@deriving yojson]
 
 val fresh : ?hint:string -> unit -> t
 
@@ -12,6 +13,3 @@ val pp : Format.formatter -> t -> unit
 
 module Set : Derivable.SetS with type elt = t
 module Map : Derivable.MapS with type key = t
-
-val to_yojson : t -> Yojson.Safe.t
-val of_yojson : Yojson.Safe.t -> (t, string) Result.result

--- a/src/constraints/efficient/clause/core.ml
+++ b/src/constraints/efficient/clause/core.ml
@@ -6,7 +6,7 @@ let not_implemented s = raise (NotImplemented s)
 type var = int
 [@@deriving yojson]
 
-module VarSet = Set.Make(Int)
+module VarSet = Set.Make(struct type t = int let compare = compare end)
 
 let shadow = ref false
 

--- a/src/constraints/efficient/clause/core.ml
+++ b/src/constraints/efficient/clause/core.ml
@@ -6,6 +6,8 @@ let not_implemented s = raise (NotImplemented s)
 type var = int
 [@@deriving yojson]
 
+module VarSet = Set.Make(Int)
+
 let shadow = ref false
 
 let with_shadow_variables f =
@@ -270,9 +272,8 @@ let fold_globals f c =
 let quantify_over x c =
   { c with globals = Var.Map.remove x c.globals }
 
-let get_info x c =
-  let (_, info) = find_ancestor_and_info x c in
-  Info.update_shadow info
+let get_info_no_shadow x c = find_ancestor_and_info x c |> snd
+let get_info x c = get_info_no_shadow x c |> Info.update_shadow
 
 let is_shadow x c =
   (* We can't use [get_info] because it can set the shadow field to false. *)

--- a/src/constraints/efficient/clause/core.ml
+++ b/src/constraints/efficient/clause/core.ml
@@ -3,38 +3,136 @@ open Colis_constraints_common
 exception NotImplemented of string
 let not_implemented s = raise (NotImplemented s)
 
-(** {2 Main Structure} *)
-
 type var = int
 [@@deriving yojson]
 
-type kind =
-  | Any
-  | Neg of Kind.t list (* uniques, sorted, less than (#kinds - 1) elements *)
-  | Pos of Kind.t
-[@@deriving yojson]
+let shadow = ref false
 
-type feat =
-  | DontKnow
-  | Absent
-  | Present of var    (* implies dir *)
-  | Maybe of var list
-[@@deriving yojson]
+let with_shadow_variables f =
+  let shadow_bak = !shadow in
+  shadow := true;
+  let v = f () in
+  shadow := shadow_bak;
+  v
 
-type info = {
-  shadow : bool ;
-  kind : kind ;
-  feats : feat Feat.Map.t ;
-  fen : bool ;                      (* implies dir *)
-  sims : (Feat.Set.t * var) list ;  (* max 1 for each variable, implies dir *)
-  nfens : Feat.Set.t list ;         (* only if not "not dir" *)
-  nsims : (Feat.Set.t * var) list ; (* only if not "not dir" *)
-}
-[@@deriving yojson]
+module Info = struct
+  type kind =
+    | Any
+    | Neg of Kind.t list (* uniques, sorted, less than (#kinds - 1) elements *)
+    | Pos of Kind.t
+  [@@deriving yojson]
+
+  type feat =
+    | DontKnow
+    | Absent
+    | Present of var    (* implies dir *)
+    | Maybe of var list
+  [@@deriving yojson]
+
+  type t = {
+    shadow : bool ;
+    kind : kind ;
+    feats : feat Feat.Map.t ;
+    fen : bool ;                      (* implies dir *)
+    sims : (Feat.Set.t * var) list ;  (* max 1 for each variable, implies dir *)
+    nfens : Feat.Set.t list ;         (* only if not "not dir" *)
+    nsims : (Feat.Set.t * var) list ; (* only if not "not dir" *)
+  }
+  [@@deriving yojson]
+
+  (* FIXME: Could maybe be a ref instead of a function. Faster? *)
+  let empty_info () = {
+    shadow  = !shadow;
+    kind = Any ;
+    feats = Feat.Map.empty ;
+    fen = false ;
+    sims = [] ;
+    nfens = [] ;
+    nsims = [] ;
+  }
+
+  let is_shadow info = info.shadow
+
+  let update_shadow info =
+    { info with shadow = info.shadow && !shadow }
+
+  let get_kind info = info.kind
+
+  let set_kind kind info = { info with kind }
+
+  let get_feat f info = Feat.Map.find_opt f info.feats
+
+  let iter_feats f info = Feat.Map.iter f info.feats
+
+  let fold_feats f e info = Feat.Map.fold f info.feats e
+
+  let for_all_feats p info = Feat.Map.for_all p info.feats
+
+  let set_feat f t info = { info with feats = Feat.Map.add f t info.feats }
+
+  let set_feat_if_none f t info = { info with feats = Feat.Map.update f (function Some t -> Some t | None -> Some t) info.feats }
+
+  let remove_feat f info = { info with feats = Feat.Map.remove f info.feats }
+
+  let remove_feats p info = { info with feats = Feat.Map.filter (fun f _ -> p f) info.feats }
+
+  let remove_all_feats info = { info with feats = Feat.Map.empty }
+
+  let has_fen info = info.fen
+
+  let set_fen info = { info with fen = true }
+
+  let iter_sims f info =
+    List.iter (fun (fs, z) -> f fs z) info.sims
+
+  let fold_sims f e info =
+    List.fold_left
+      (fun e (fs, z) -> f fs z e)
+      e info.sims
+
+  (** {3 ¬ Fences} *)
+
+  let remove_nfens info =
+    { info with nfens = [] }
+
+  let not_implemented_nfens info =
+    if info.nfens <> [] then
+      not_implemented "nfens"
+
+  (** {3 ¬ Similarities} *)
+
+  let not_implemented_nsims info =
+    if info.nsims <> [] then
+      not_implemented "nsims"
+
+end
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 module IMap = Derivable.MakeMap(Derivable.Int)
 
-type info_or_son = Info of info | Son of var
+type info_or_son = Info of Info.t | Son of var
 [@@deriving yojson]
 
 type t = {
@@ -58,7 +156,7 @@ let pp_debug fmt c =
         | Info _ -> ())
   in
   let pp_info fmt info =
-    fpf fmt "shadow: %b@\n" info.shadow;
+    fpf fmt "shadow: %b@\n" info.Info.shadow;
     fpf fmt "kind: ";
     (match info.kind with
      | Any -> fpf fmt "*"
@@ -70,7 +168,7 @@ let pp_debug fmt c =
       (fun f t ->
          fpf fmt "  %a -> " Feat.pp f;
          (match t with
-          | DontKnow -> fpf fmt "?"
+          | Info.DontKnow -> fpf fmt "?"
           | Absent -> fpf fmt "X"
           | Present y -> fpf fmt "%d" y
           | Maybe ys -> fpf fmt "maybe: "; Format.pp_print_list ~pp_sep:(fun fmt () -> fpf fmt ", ") Format.pp_print_int fmt ys);
@@ -106,31 +204,11 @@ let empty = {
   info = IMap.empty
 }
 
-let shadow = ref false
-
-(* FIXME: Could maybe be a ref instead of a function. Faster? *)
-let empty_info () = {
-  shadow  = !shadow;
-  kind = Any ;
-  feats = Feat.Map.empty ;
-  fen = false ;
-  sims = [] ;
-  nfens = [] ;
-  nsims = [] ;
-}
-
-let with_shadow_variables f =
-  let shadow_bak = !shadow in
-  shadow := true;
-  let v = f () in
-  shadow := shadow_bak;
-  v
-
 let fresh_var =
   let x = ref 0 in
   fun c ->
     incr x;
-    (!x, { c with info = IMap.add !x (Info (empty_info ())) c.info })
+    (!x, { c with info = IMap.add !x (Info (Info.empty_info ())) c.info })
 
 let hash x = x
 
@@ -155,8 +233,8 @@ let identify x y merge c =
   let rec identify x y =
     match IMap.find x c.info, IMap.find y c.info with
     | Info info_x, Info info_y ->
-      let info_x = { info_x with shadow = info_x.shadow && !shadow } in
-      let info_y = { info_y with shadow = info_y.shadow && !shadow } in
+      let info_x = Info.update_shadow info_x in
+      let info_y = Info.update_shadow info_y in
       let info =
         c.info
         |> IMap.add x (Son y)
@@ -194,12 +272,12 @@ let quantify_over x c =
 
 let get_info x c =
   let (_, info) = find_ancestor_and_info x c in
-  { info with shadow = info.shadow && !shadow }
+  Info.update_shadow info
 
 let is_shadow x c =
   (* We can't use [get_info] because it can set the shadow field to false. *)
   let (_, info) = find_ancestor_and_info x c in
-  info.shadow
+  Info.is_shadow info
 
 let set_info x c info =
   let rec set_info x =
@@ -238,49 +316,16 @@ let iter_equalities f c =
        | Info _ -> ())
     c.info
 
-(** {2 Info Helpers} *)
-
-(** {3 Kinds} *)
-
-let get_kind info = info.kind
-
-let set_kind kind info = { info with kind }
-
-(** {3 Features} *)
-
-let get_feat f info = Feat.Map.find_opt f info.feats
-
-let iter_feats f info = Feat.Map.iter f info.feats
-
-let fold_feats f e info = Feat.Map.fold f info.feats e
-
-let for_all_feats p info = Feat.Map.for_all p info.feats
-
-let set_feat f t info = { info with feats = Feat.Map.add f t info.feats }
-
-let set_feat_if_none f t info = { info with feats = Feat.Map.update f (function Some t -> Some t | None -> Some t) info.feats }
-
-let remove_feat f info = { info with feats = Feat.Map.remove f info.feats }
-
-let remove_feats p info = { info with feats = Feat.Map.filter (fun f _ -> p f) info.feats }
-
-let remove_all_feats info = { info with feats = Feat.Map.empty }
-
-(** {3 Fences} *)
-
-let has_fen info = info.fen
-
-let set_fen info = { info with fen = true }
 
 (** {3 Similarities} *)
 
 let remove_sim y c info =
-  { info with
-    sims =
-      List.filter
-        (fun (_, z) ->
-           not (equal y z c))
-        info.sims }
+  Info.{ info with
+         sims =
+           List.filter
+             (fun (_, z) ->
+                not (equal y z c))
+             info.sims }
 
 let update_sim y upd c info =
   let rec update_sim = function
@@ -288,15 +333,7 @@ let update_sim y upd c info =
     | (fs, z) :: sims when equal y z c -> (upd (Some fs), z) :: sims
     | (fs, z) :: sims -> (fs, z) :: update_sim sims
   in
-  { info with sims = update_sim info.sims }
-
-let iter_sims f info =
-  List.iter (fun (fs, z) -> f fs z) info.sims
-
-let fold_sims f e info =
-  List.fold_left
-    (fun e (fs, z) -> f fs z e)
-    e info.sims
+  Info.{ info with sims = update_sim info.sims }
 
 let update_info_for_all_similarities upd x info c =
   List.fold_left
@@ -304,21 +341,6 @@ let update_info_for_all_similarities upd x info c =
        update_info z c (upd fs z))
     (set_info x c (upd Feat.Set.empty x info))
     info.sims
-
-(** {3 ¬ Fences} *)
-
-let remove_nfens info =
-  { info with nfens = [] }
-
-let not_implemented_nfens info =
-  if info.nfens <> [] then
-    not_implemented "nfens"
-
-(** {3 ¬ Similarities} *)
-
-let not_implemented_nsims info =
-  if info.nsims <> [] then
-    not_implemented "nsims"
 
 let remove_nsim x y c = (* FIXME: order of the arguments? *)
   update_info x c @@ fun info ->
@@ -354,7 +376,7 @@ let simplify c =
      subsequent modifications.
      This operation is pretty costly: #literals * log(#variables). *)
   let rec gather_accessibles_from accessibles x =
-    fold_feats
+    Info.fold_feats
       (fun _ t accessibles ->
          match t with
          | DontKnow | Absent -> accessibles
@@ -398,7 +420,7 @@ let simplify c =
               feats =
                 Feat.Map.map_filter
                   (function
-                    | DontKnow -> Some DontKnow
+                    | Info.DontKnow -> Some Info.DontKnow
                     | Absent -> Some Absent
                     | Present y ->
                       let y =  find_ancestor y c in

--- a/src/constraints/efficient/clause/core.mli
+++ b/src/constraints/efficient/clause/core.mli
@@ -5,6 +5,8 @@ open Colis_constraints_common
 type var
 (** Type of the variables. *)
 
+module VarSet : Set.S with type elt = var
+
 (** {2 Information} *)
 
 module Info : sig
@@ -88,6 +90,9 @@ val is_shadow : var -> t -> bool
 val get_info : var -> t -> Info.t
 (** [get_info x c] returns the information associated with variable [x] in
    clause [c], after having updated the [shadow] field. *)
+
+val get_info_no_shadow : var -> t -> Info.t
+(** Same as [get_info] but does not update the [shadow] field. *)
 
 val set_info : var -> t -> Info.t -> t
 

--- a/src/constraints/efficient/clause/core.mli
+++ b/src/constraints/efficient/clause/core.mli
@@ -2,15 +2,57 @@
 
 open Colis_constraints_common
 
-(** {2 Main Structure} *)
-
 type var
 (** Type of the variables. *)
 
-type info
-(** Type of the information we have on a variable. *)
+(** {2 Information} *)
 
-type t
+module Info : sig
+  type t
+
+  val is_shadow : t -> bool
+  val update_shadow : t -> t
+
+  type kind = Any | Neg of Kind.t list | Pos of Kind.t
+  val get_kind : t -> kind
+  val set_kind : kind -> t -> t
+
+  type feat = DontKnow | Absent | Present of var | Maybe of var list
+  val get_feat : Feat.t -> t -> feat option
+  val iter_feats : (Feat.t -> feat -> unit) -> t -> unit
+  val fold_feats : (Feat.t -> feat -> 'a -> 'a) -> 'a -> t -> 'a
+  val for_all_feats : (Feat.t -> feat -> bool) -> t -> bool
+  val set_feat : Feat.t -> feat -> t -> t
+  val set_feat_if_none : Feat.t -> feat -> t -> t
+  val remove_feat : Feat.t -> t -> t
+  val remove_feats : (Feat.t -> bool) -> t -> t
+  val remove_all_feats : t -> t
+
+  val has_fen : t -> bool
+  val set_fen : t -> t
+
+  val iter_sims : (Feat.Set.t -> var -> unit) -> t -> unit
+  val fold_sims : (Feat.Set.t -> var -> 'a -> 'a) -> 'a -> t -> 'a
+
+  val remove_nfens : t -> t
+  (** Remove all nfens in the given [info]. *)
+
+  val not_implemented_nfens : t -> unit
+  (* Raise [NotImplemented "nfens"] if there are nfens in the given [info].
+
+     FIXME: should not be required if everything is correctly implemented. They
+     are here to denote places where work has to be done to support nfens. *)
+
+  val not_implemented_nsims : t -> unit
+  (* Raise [NotImplemented "nsims"] if there are nsims in the given [info].
+
+     FIXME: should not be required if everything is correctly implemented. They
+     are here to denote places where work has to be done to support nsims. *)
+end
+
+(** {2 Main Structure} *)
+
+type t [@@deriving yojson]
 (** Type of an irreducible existential clause. *)
 
 val empty : t
@@ -26,7 +68,7 @@ val syntactic_compare : var -> var -> int
 (** Comparison not in the structure but syntactically. Implies equality in the
     structure. *)
 
-val identify : var -> var -> (info -> info -> info) ->  t -> t
+val identify : var -> var -> (Info.t -> Info.t -> Info.t) -> t -> t
 (** Identify two variables. After that, they are "equal" in the structure. The function talking about infos is here to tell to the structure how to merge the info of the two variables. *)
 
 val fresh_var : t -> (var * t)
@@ -41,118 +83,63 @@ val fold_globals : (var -> 'a -> 'a) -> t -> 'a -> 'a
 
 val quantify_over : Colis_constraints_common.Var.t -> t -> t
 
-val with_shadow_variables : (unit -> 'a) -> 'a
-(** [with_initial f] runs [f] in an environment where all new variables are
-    declared to be shadow. *)
-
 val is_shadow : var -> t -> bool
 
-val get_info : var -> t -> info
+val get_info : var -> t -> Info.t
+(** [get_info x c] returns the information associated with variable [x] in
+   clause [c], after having updated the [shadow] field. *)
 
-val set_info : var -> t -> info -> t
+val set_info : var -> t -> Info.t -> t
 
-val update_info : var -> t -> (info -> info) -> t
-
-val fold_infos : (var -> info -> 'a -> 'a) -> t -> 'a -> 'a
+val update_info : var -> t -> (Info.t -> Info.t) -> t
+(** Equivalent to [get_info x c |> f |> set_info x c]. *)
 
 val filter_infos : (var -> bool) -> t -> t
 
-val iter_infos : (var -> info -> unit) -> t -> unit
+val fold_infos : (var -> Info.t -> 'a -> 'a) -> t -> 'a -> 'a
+(** [fold_infos f c e] computes [f] in order for all variables and associated
+   informations in the all clause [c], passing the result to the next
+   computation. This does not update the [shadow] field. *)
+
+val iter_infos : (var -> Info.t -> unit) -> t -> unit
+(* Iters on all the variables and associated informations, without updating the
+   [shadow] field. *)
 
 val iter_equalities : (var -> var -> unit) -> t -> unit
 
-
-(** {2 Helpers} *)
-
-(** {3 kinds} *)
-
-type kind = Any | Neg of Kind.t list | Pos of Kind.t
-
-val get_kind : info -> kind
-
-val set_kind : kind -> info -> info
-
-(** {3 feats} *)
-
-type feat = DontKnow | Absent | Present of var | Maybe of var list
-
-val get_feat : Feat.t -> info -> feat option
-
-val iter_feats : (Feat.t -> feat -> unit) -> info -> unit
-val fold_feats : (Feat.t -> feat -> 'a -> 'a) -> 'a -> info -> 'a
-
-val for_all_feats : (Feat.t -> feat -> bool) -> info -> bool
-
-val set_feat : Feat.t -> feat -> info -> info
-
-val set_feat_if_none : Feat.t -> feat -> info -> info
-
-val remove_feat : Feat.t -> info -> info
-
-val remove_feats : (Feat.t -> bool) -> info -> info
-
-val remove_all_feats : info -> info
-
-(** {3 fens} *)
-
-val has_fen : info -> bool
-
-val set_fen : info -> info
-
 (** {3 sims} *)
 
-val remove_sim : var -> t -> info -> info
+val remove_sim : var -> t -> Info.t -> Info.t
 (** [remove_sim y c info] removes all references to variables equal to [y] (wrt.
     structure [c]) in [info]. *)
 
-val update_sim : var -> (Feat.Set.t option -> Feat.Set.t) -> t -> info -> info
+val update_sim : var -> (Feat.Set.t option -> Feat.Set.t) -> t -> Info.t -> Info.t
 (** [update_sim y f c info] updates the sims in [info] by calling [f None] if
     there is no sim for [y] or [Some gs] if there is a sim [~gs y]. *)
 
-val iter_sims : (Feat.Set.t -> var -> unit) -> info -> unit
-val fold_sims : (Feat.Set.t -> var -> 'a -> 'a) -> 'a -> info -> 'a
-
 val update_info_for_all_similarities :
-  (Feat.Set.t -> var -> info -> info) ->
-  var -> info -> t -> t
+  (Feat.Set.t -> var -> Info.t -> Info.t) ->
+  var -> Info.t -> t -> t
 (** [update_info_for_all_similarities upd x info] takes a clause and
     applies the [upd] function to all the info records of variables that are
     similar to the given info (including it). *)
-
-(** {3 nfens} *)
-
-val remove_nfens : info -> info
-(** Remove all nfens in the given [info]. *)
-
-val not_implemented_nfens : info -> unit
-(* Raise [NotImplemented "nfens"] if there are nfens in the given [info].
-
-   FIXME: should not be required if everything is correctly implemented. They
-   are here to denote places where work has to be done to support nfens. *)
 
 (** {3 nsims} *)
 
 val remove_nsims : var -> t -> t
 (** Remove all nsims in the given [info]. *)
 
-val not_implemented_nsims : info -> unit
-(* Raise [NotImplemented "nsims"] if there are nsims in the given [info].
-
-   FIXME: should not be required if everything is correctly implemented. They
-   are here to denote places where work has to be done to support nsims. *)
-
 (** {2 Garbage Collection} *)
 
 val simplify : t -> t
 (** Removes all variables that are not accessible from the globals. *)
 
-(** {2 Should Disappear}
+val with_shadow_variables : (unit -> 'a) -> 'a
+(** [with_initial f] runs [f] in an environment where all new variables are
+    declared to be shadow. *)
 
-    FIXME *)
+(** {2 Should Disappear} FIXME *)
 
 val not_implemented : string -> 'a
 
 val pp_debug : Format.formatter -> t -> unit
-
-val to_yojson : t -> Yojson.Safe.t
-val of_yojson : Yojson.Safe.t -> (t, string) Result.result

--- a/src/constraints/efficient/clause/prettyPrinter.ml
+++ b/src/constraints/efficient/clause/prettyPrinter.ml
@@ -3,9 +3,9 @@ let fpf = Format.fprintf
 
 let pp = Core.pp_debug
 
-let pp_as_dot ~name fmt c =
-  let c = Core.simplify c in
-  let fresh = let c = ref 0 in fun () -> incr c; "fresh_" ^ string_of_int !c in
+module Dot = struct
+  let fresh = let c = ref 0 in fun () -> incr c; "fresh_" ^ string_of_int !c
+
   let pp_node fmt ?text x =
     Format.kasprintf
       (fun cont ->
@@ -21,13 +21,12 @@ let pp_as_dot ~name fmt c =
            fpf fmt "%d [label=< <TABLE BORDER=\"0\" CELLBORDER=\"1\" CELLSPACING=\"0\"><TR><TD></TD></TR></TABLE> >];@\n"
              (Core.hash x))
       "%a"
-  in
+
   let pp_flat_edge fmt x y = (* assumes x and y are hashed *)
     (* let x = Core.hash x in
-    let y = Core.hash y in *)
+       let y = Core.hash y in *)
     let (x, y) = if x < y then (x, y) else (y, x) in
     fpf fmt "{ rank=same; %d -> %d [style=dotted,arrowhead=none,label=\"%a\"]; }@\n" x y
-  in
   let pp_kind_and_fen fmt info =
     (match Core.get_kind info with
      | Any -> ()
@@ -39,8 +38,8 @@ let pp_as_dot ~name fmt c =
        fpf fmt "<TR><TD>%a</TD></TR>" Kind.pp kind);
     if Core.has_fen info then
       fpf fmt "<TR><TD>full</TD></TR>"
-  in
-  let pp_feats fmt x info_x =
+
+  let pp_feats fmt c x info_x =
     if not (Core.is_shadow x c) then
       Core.iter_feats
         (fun f -> function
@@ -62,8 +61,8 @@ let pp_as_dot ~name fmt c =
                ys
         )
         info_x
-  in
-  let pp_sims fmt x info_x =
+
+  let pp_sims fmt c x info_x =
     let hx = Core.hash x in
     Core.iter_sims
       (fun fs y ->
@@ -72,43 +71,48 @@ let pp_as_dot ~name fmt c =
          if hx < hy && not (Core.is_shadow x c) && not (Core.is_shadow y c) then
            pp_flat_edge fmt hx hy (fun fmt -> fpf fmt "~%a" Feat.Set.pp) fs)
       info_x
-  in
-  let pp fmt c =
-    Core.iter_infos
-      (fun x info_x ->
-         if not (Core.is_shadow x c) then
+
+  let pp ~name fmt c =
+    let c = Core.simplify c in
+    let pp fmt c =
+      Core.iter_infos
+        (fun x info_x ->
+           if not (Core.is_shadow x c) then
+             let text =
+               match Core.externalise x c with
+               | [] -> None
+               | xs ->
+                 xs
+                 |> List.sort Var.compare
+                 |> List.map Var.to_string
+                 |> String.concat ", "
+                 |> (fun s -> Some s)
+             in
+             pp_node fmt ?text x
+               pp_kind_and_fen info_x)
+        c;
+      fpf fmt "@\n";
+      Core.iter_equalities
+        (fun x y ->
            let text =
              match Core.externalise x c with
              | [] -> None
              | xs ->
                xs
-               |> List.sort Var.compare
                |> List.map Var.to_string
                |> String.concat ", "
                |> (fun s -> Some s)
            in
            pp_node fmt ?text x
-             pp_kind_and_fen info_x)
-      c;
-    fpf fmt "@\n";
-    Core.iter_equalities
-      (fun x y ->
-         let text =
-           match Core.externalise x c with
-           | [] -> None
-           | xs ->
-             xs
-             |> List.map Var.to_string
-             |> String.concat ", "
-             |> (fun s -> Some s)
-         in
-         pp_node fmt ?text x
-           (fun _fmt () -> ()) ();
-         pp_flat_edge fmt (Core.hash x) (Core.hash y) (fun fmt () -> fpf fmt "=") ())
-      c;
-    fpf fmt "@\n";
-    Core.iter_infos (pp_feats fmt) c;
-    fpf fmt "@\n";
-    Core.iter_infos (pp_sims fmt) c
-  in
-  fpf fmt "@[<h 2>digraph %S {@\nnode [shape=plaintext];@\nedge [arrowhead=none];@\n@\n%a@]@\n}" name pp c
+             (fun _fmt () -> ()) ();
+           pp_flat_edge fmt (Core.hash x) (Core.hash y) (fun fmt () -> fpf fmt "=") ())
+        c;
+      fpf fmt "@\n";
+      Core.iter_infos (pp_feats fmt c) c;
+      fpf fmt "@\n";
+      Core.iter_infos (pp_sims fmt c) c
+    in
+    fpf fmt "@[<h 2>digraph %S {@\nnode [shape=plaintext];@\nedge [arrowhead=none];@\n@\n%a@]@\n}" name pp c
+end
+
+let pp_as_dot = Dot.pp

--- a/src/constraints/efficient/clause/prettyPrinter.ml
+++ b/src/constraints/efficient/clause/prettyPrinter.ml
@@ -28,7 +28,7 @@ module Dot = struct
     let (x, y) = if x < y then (x, y) else (y, x) in
     fpf fmt "{ rank=same; %d -> %d [style=dotted,arrowhead=none,label=\"%a\"]; }@\n" x y
   let pp_kind_and_fen fmt info =
-    (match Core.get_kind info with
+    (match Core.Info.get_kind info with
      | Any -> ()
      | Neg kinds ->
        fpf fmt "<TR>";
@@ -36,14 +36,14 @@ module Dot = struct
        fpf fmt "</TR>"
      | Pos kind ->
        fpf fmt "<TR><TD>%a</TD></TR>" Kind.pp kind);
-    if Core.has_fen info then
+    if Core.Info.has_fen info then
       fpf fmt "<TR><TD>full</TD></TR>"
 
   let pp_feats fmt c x info_x =
     if not (Core.is_shadow x c) then
-      Core.iter_feats
+      Core.Info.iter_feats
         (fun f -> function
-           | Core.DontKnow -> () (* FIXME *)
+           | Core.Info.DontKnow -> () (* FIXME *)
            | Absent ->
              let y = fresh () in
              fpf fmt "%s [label=\"⊥\"];@\n" y;
@@ -64,7 +64,7 @@ module Dot = struct
 
   let pp_sims fmt c x info_x =
     let hx = Core.hash x in
-    Core.iter_sims
+    Core.Info.iter_sims
       (fun fs y ->
          let hy = Core.hash y in
          (* only one variable prints this *)

--- a/src/constraints/efficient/clause/prettyPrinter.ml
+++ b/src/constraints/efficient/clause/prettyPrinter.ml
@@ -39,8 +39,8 @@ module Dot = struct
     if Core.Info.has_fen info then
       fpf fmt "<TR><TD>full</TD></TR>"
 
-  let pp_feats fmt c x info_x =
-    if not (Core.is_shadow x c) then
+  let pp_feats fmt shadows x info_x =
+    if not (Core.VarSet.mem x shadows) then
       Core.Info.iter_feats
         (fun f -> function
            | Core.Info.DontKnow -> () (* FIXME *)
@@ -51,33 +51,86 @@ module Dot = struct
            | Present y ->
              (* only print arrows to non-initial variables. bc initial variables
                 wont be printed at all *)
-             if not (Core.is_shadow y c) then
+             if not (Core.VarSet.mem y shadows) then
                fpf fmt "%d -> %d [label=\"%a\"];@\n" (Core.hash x) (Core.hash y) Feat.pp f
            | Maybe ys ->
              List.iter
                (fun y ->
-                  if not (Core.is_shadow y c) then
+                  if not (Core.VarSet.mem y shadows) then
                     fpf fmt "%d -> %d [style=dashed,label=< <I>%a</I>? >];@\n" (Core.hash x) (Core.hash y) Feat.pp f)
                ys
         )
         info_x
 
-  let pp_sims fmt c x info_x =
+  let pp_sims fmt shadows x info_x =
     let hx = Core.hash x in
     Core.Info.iter_sims
       (fun fs y ->
          let hy = Core.hash y in
          (* only one variable prints this *)
-         if hx < hy && not (Core.is_shadow x c) && not (Core.is_shadow y c) then
+         if hx < hy && not (Core.VarSet.mem x shadows) && not (Core.VarSet.mem y shadows) then
            pp_flat_edge fmt hx hy (fun fmt -> fpf fmt "~%a" Feat.Set.pp) fs)
       info_x
 
+  let compute_shadows c =
+    (* Each node has a 'shadow' flag in the constraint. However, if we just
+       consider this flag in the printing, it gives weird results. This is
+       because there can be nodes that are non-shadow with parents that are.
+       This function computes a set of non-shadow nodes by taking (a) all the
+       nodes that are flagged as non-shadow, and (b) all the nodes that are
+       parents from a non-shadow node. *)
+    let rec handle_node x (seen, shadows) =
+      if Core.VarSet.mem x seen then
+        (* If the node has already been seen, no need to do anything. *)
+        (seen, shadows)
+      else
+        (
+          let info_x = Core.get_info_no_shadow x c in
+          (* Firstly, mark the node [x] as seen. Moreover, if the node [x] has
+             the shadow flag, then add it to the set of shadow nodes. We might
+             later remove it from there. *)
+          let seen = Core.VarSet.add x seen in
+          let shadows =
+            if Core.Info.is_shadow info_x then
+              Core.VarSet.add x shadows
+            else
+              shadows
+          in
+          (* Secondly, iterate through all the children of [x], handling them
+             all, then checking whether they are shadow or not. If they are not
+             shadow, remove them from the [shadows] set. This is the job of
+             [handle_node_and_mark_parent]. *)
+          Core.Info.fold_feats
+            (fun _ feat (seen, shadows) ->
+               match feat with
+               | DontKnow | Absent -> (seen, shadows)
+               | Present y -> handle_node_and_mark_parent ~parent:x y (seen, shadows)
+               | Maybe ys ->
+                 List.fold_left (fun e y -> handle_node_and_mark_parent ~parent:x y e) (seen, shadows) ys)
+            (seen, shadows)
+            info_x
+        )
+    and handle_node_and_mark_parent ~parent y (seen, shadows) =
+      (* This function handles the node [y]. Once this is done, we know whether
+         it is a shadow node or not. If it is not, then we mark its parent [x]
+         as non-shadow also. *)
+      let (seen, shadows) = handle_node y (seen, shadows) in
+      if Core.VarSet.mem y shadows then
+        (seen, shadows)
+      else
+        (seen, Core.VarSet.remove parent shadows)
+    in
+    (Core.VarSet.empty, Core.VarSet.empty)
+    |> Core.fold_infos (fun x _ e -> handle_node x e) c
+    |> snd
+
   let pp ~name fmt c =
     let c = Core.simplify c in
+    let shadows = compute_shadows c in
     let pp fmt c =
       Core.iter_infos
         (fun x info_x ->
-           if not (Core.is_shadow x c) then
+           if not (Core.VarSet.mem x shadows) then
              let text =
                match Core.externalise x c with
                | [] -> None
@@ -108,9 +161,9 @@ module Dot = struct
            pp_flat_edge fmt (Core.hash x) (Core.hash y) (fun fmt () -> fpf fmt "=") ())
         c;
       fpf fmt "@\n";
-      Core.iter_infos (pp_feats fmt c) c;
+      Core.iter_infos (pp_feats fmt shadows) c;
       fpf fmt "@\n";
-      Core.iter_infos (pp_sims fmt c) c
+      Core.iter_infos (pp_sims fmt shadows) c
     in
     fpf fmt "@[<h 2>digraph %S {@\nnode [shape=plaintext];@\nedge [arrowhead=none];@\n@\n%a@]@\n}" name pp c
 end


### PR DESCRIPTION
This PR:

- Cleans up a bit the internal interface of constraints.

- Makes the constraint printer more aware of how "shadows" work. They are a mechanism to hide nodes in the printed output. Without it, with all the nodes introduced by the FHS and the unpacking, the printed output would be unreadable. The previous printer was hiding too many nodes, giving weirdly looking (and sometimes unexploitable) results. This one gives much better results.

@benozol I don't need your input on that. However, I wanted to check first that you had not changed anything wrt the constraints? I'm a bit lost in all the changes and I wouldn't want to break your code for such a minor change.