### PR TITLE
Rework Dockerfile and improve CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
-language: c
-sudo: required
 services:
   - docker
 
-## We build on as many OCaml version as we can support. These versions
-## are in fact tags for the ocaml/opam2 Docker image that we pull.
-
 env:
-  - TAG=4.09
-  - TAG=4.08
-  - TAG=4.07
-  - TAG=4.06
-  - TAG=4.05
+  global:
+    - TARGET=tester
+  jobs:
+    - TAG=4.10 TARGET=prover
+    - TAG=4.09
+    - TAG=4.08
 
 script:
   - docker build
       --build-arg "TAG=$TAG"
       --build-arg "SWITCH=$SWITCH"
       --tag colisanr/colis-language:$TRAVIS_BRANCH
+      --target "$TARGET"
       .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,82 +1,85 @@
-## =============================== [ Basis ] =============================== ##
+## ============================== [ Basis ] ================================= ##
 
 ARG TAG=latest
 ARG IMAGE=ocaml/opam2:$TAG
 
-FROM $IMAGE
+FROM $IMAGE as basis
 
-MAINTAINER Nicolas Jeannerod
+ENV LANGUAGEDIR=/home/opam/colis-language
+ENV PROVERSDIR=/home/opam/provers
 
-ENV OPAMFILE=colis-language.opam
+ENV Z3="z3-4.8.7"
+ENV CVC4="cvc4-1.6"
+ENV ALTERGO="alt-ergo.2.3.0"
+
 ARG SWITCH=
-
 RUN [ -z "$SWITCH" ] || opam switch create "$SWITCH"
 
 WORKDIR /home/opam/opam-repository
-RUN git pull; opam update
-
-## ============================ [ Dependencies ] ============================ ##
+RUN git pull && opam update
 
 RUN sudo apt-get update
+
+## ======================= [ Basis with dependencies ] ====================== ##
+
+FROM basis as basis-with-deps
+
 RUN sudo apt-get install -qq -yy curl autoconf automake
 RUN sudo apt-get install -qq -yy debianutils libgmp-dev m4 perl pkg-config zlib1g-dev
 
-WORKDIR /home/opam/colis-language
+WORKDIR "$LANGUAGEDIR"
 COPY colis-language.opam .
-RUN sudo chown opam colis-language.opam
-
-# The following and the `apt-get install` above could be accomplished by something like
-# `opam install --only-deps` if it was supported...
+RUN sudo chown -R opam .
 
 # Extract pin-depends from opam file and pin them
 RUN opam show . -f pin-depends: 2>/dev/null \
   | tr -s '[]"' ' ' \
   | xargs -n2 opam pin -n
 
-# Extract dependencies from opam file and install their dependencies
 RUN opam install . --deps-only --with-test --with-doc
 
-## ========================= [ Solvers for Why3 ] =========================== ##
-## Must cover all provers used in the Why3 sessions
+## ============================== [ Builder ] =============================== ##
 
-# All manually installed provers reside in this directory
-WORKDIR /home/opam/provers
-RUN sudo chown -R opam .
+FROM basis-with-deps as builder
 
-# Make sure that Why3 is installed
-RUN opam depext -i why3
-RUN eval $(opam env) \
-  && why3 config --detect-provers
-
-# Versions
-ENV Z3="z3-4.8.7"
-ENV CVC4="cvc4-1.6"
-ENV ALTERGO="alt-ergo.2.3.0"
-
-# Install Z3 in provers $Z3
-RUN eval $(opam env) \
-  && curl -sL -o "$Z3.zip" "https://github.com/Z3Prover/z3/releases/download/$Z3/$Z3-x64-ubuntu-16.04.zip" \
-  && unzip -q "$Z3.zip" \
-  && why3 config --add-prover z3 "$Z3" "$PWD/$Z3-x64-ubuntu-16.04/bin/z3"
-
-# Install CVC4 as provers/$CVC4
-RUN eval $(opam env) \
-  && curl -sL -o "$CVC4" "http://cvc4.cs.stanford.edu/downloads/builds/x86_64-linux-opt/$CVC4-x86_64-linux-opt" \
-  && chmod +x "$CVC4" \
-  && why3 config --add-prover cvc4 "$CVC4" "$PWD/$CVC4"
-
-# Register Alt-ergo
-RUN eval $(opam env) \
-  && opam depext -i "$ALTERGO" \
-  && why3 config --add-prover alt-ergo "$ALTERGO" "$(which alt-ergo)"
-
-RUN eval $(opam env) \
-  && why3 --list-provers
-
-## =============================== [ Build ] ================================ ##
-
-WORKDIR /home/opam/colis-language
 COPY . .
 RUN sudo chown -R opam .
 
-RUN eval $(opam env) && make ci
+RUN eval $(opam env) && make build
+
+## =============================== [ Tester ] =============================== ##
+
+FROM builder as tester
+
+RUN eval $(opam env) && make doc && make test
+RUN eval $(opam env) && make install && make uninstall
+RUN eval $(opam env) && make clean
+
+## ========================= [ Basis with provers ] ========================= ##
+
+FROM basis as basis-with-provers
+
+WORKDIR "$PROVERSDIR"
+RUN sudo chown -R opam .
+
+RUN opam depext -i "$ALTERGO"
+RUN eval $(opam env) && cp "$(which alt-ergo)" "$ALTERGO"
+
+RUN curl -sL -o "$CVC4" "http://cvc4.cs.stanford.edu/downloads/builds/x86_64-linux-opt/$CVC4-x86_64-linux-opt"
+RUN chmod +x "$CVC4"
+
+RUN curl -sL -o "$Z3.zip" "https://github.com/Z3Prover/z3/releases/download/$Z3/$Z3-x64-ubuntu-16.04.zip"
+RUN unzip -q "$Z3.zip"
+RUN cp "$Z3"-x64-ubuntu-16.04/bin/z3 "$Z3"
+
+## =============================== [ Prover ] =============================== ##
+
+FROM builder as prover
+COPY --from=basis-with-provers "$PROVERSDIR" "$PROVERSDIR"
+
+RUN eval $(opam env) && why3 config --add-prover alt-ergo "$ALTERGO" "$PROVERSDIR"/"$ALTERGO"
+RUN eval $(opam env) && why3 config --add-prover cvc4 "$CVC4" "$PROVERSDIR"/"$CVC4"
+RUN eval $(opam env) && why3 config --add-prover z3 "$Z3" "$PROVERSDIR"/"$Z3"
+
+WORKDIR "$LANGUAGEDIR"
+RUN eval $(opam env) && make replay-proofs

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,13 @@
 replay-concrete-proofs=$(patsubst %, replay-concrete-proof-%, auxiliaries semantics interpreter)
 replay-symbolic-proofs=$(patsubst %, replay-symbolic-proof-%, collection symbolicInterpreter)
 
-.PHONY: ci build test doc clean install uninstall \
+.PHONY: build test doc clean install uninstall \
   extract-why3 clean-why3 replay-proofs \
   $(replay-concrete-proofs) $(replay-symbolic-proofs)
 
 build: extract-why3
 	dune build @install
 	ln -sf _build/install/default/bin .
-
-# Do everything for continuous integration
-ci: build doc test replay-proofs install uninstall clean
 
 clean: clean-why3
 	dune clean
@@ -29,9 +26,6 @@ doc: build
 
 test: build
 	dune runtest
-
-# Do everything for continuous integration
-ci: build doc test replay-proofs install uninstall clean
 
 ## Extract Why3 to OCaml
 


### PR DESCRIPTION
This PR rewrites the whole Dockerfile. It uses so called "multi-stage builds" that allow to run only part of a Dockerfile, and to define some form of graph dependencies (instead of the ordered dependencies usual Dockerfile use).

This allows (both are easily possible separately but not together):
- to only build and test the artifact without installing the provers or replaying the proofs
- to cache the installation of provers even if there are changes in files.

After this change was done, I used it to:

- configure travis to only run tests by default, and replay proofs only on one job (fix #128)
- add CI on OCaml 4.10; remove CI on OCaml 4.05, 4.06, 4.07 (fix #127)
- cleanup makefile
- cleanup travis.yml

As a consequence the two first points, the CI is now much faster. It consists in only 3 jobs of around 10, 10 and 20 minutes. It was before made of 5 jobs of 20 minutes each. When submitting a PR, for instance, Travis runs twice all the jobs with a limit of 5 jobs per organisation, which means that it now takes only 20 minutes (with actually 2x10 minutes saved that can be used on other jobs) against 40 before.

@benozol Does that sound good to you? (If yes, I guess you can just merge this directly.)

---

The following table gives an idea of the time spent (on my laptop) in each stage of the Dockerfile.

| Stage                       | Depends on                                          | Time     |
|----------------------------|-----------------------------------------------------|-----------|
| `basis`                      | the `TAG` argument                               | 1-3 min |
| `basis-with-deps`     | `basis`, the file `colis-language.opam`  | 8 min    |
| `builder`                   | `basis-with-deps`, all the other files       | 1 min    |
| `tester`                     | `builder`                                                 | 1 min    |
| `basis-with-provers` | `basis`                                                   | 3 min    |
| `prover`                    |`basis-with-deps`, `basis-with-provers` | 8 min    | 

The following table gives an idea of the time spent (on my laptop) for full builds and rebuilds of the targets `builder` and `prover` after having changed the `colis-language.opam` file or any otherfile.

<table>
    <thead>
        <tr>
            <th>Target</th>
            <th>Rebuild after change to</th>
            <th>Uses cache for</th>
            <th>Time</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td rowspan="3"><code>tester</code></td>
            <td></td>
            <td></td>
            <td>12 min</td>
        </tr>
        <tr>
            <td><code>colis-language.opam</code></td>
            <td><code>basis</code></td>
            <td>9 min</td>
        </tr>
        <tr>
            <td>any other file</td>
            <td><code>basis</code>, <code>basis-with-deps</code></td>
            <td>2 min</td>
        </tr>
        <tr>
            <td rowspan="3"><code>prover</code></td>
            <td></td>
            <td></td>
            <td>22 min</td>
        </tr>
        <tr>
            <td><code>colis-language.opam</code></td>
            <td><code>basis</code>, <code>basis-with-provers</code></td>
            <td>16 min</td>
        </tr>
        <tr>
            <td>any other file</td>
            <td><code>basis</code>, <code>basis-with-deps</code>,<br/><code>basis-with-provers</code></td>
            <td>9 min</td>
        </tr>
    </tbody>
</table>
