### PR TITLE
Plug transducers backend into CLI of symbolic interpreter

### DIFF
--- a/src/colis.ml
+++ b/src/colis.ml
@@ -165,17 +165,19 @@ let exit_code (_, errors, failures) =
   else (* Exit 0, if there aren’t any errors or failures *)
     exit 0
 
-type 'backend_config config = {
+type sym_config = {
   loop_limit: int;
   stack_size: int;
   filesystem_spec : FilesystemSpec.t;
-  backend : 'backend_config;
 }
 
 module SymbolicConstraints = struct
 
   type state = SymbolicUtility.Constraints.state
   type sym_state = SymbolicUtility.Constraints.sym_state
+  type config = SymbolicUtility.Constraints.config = {
+    prune_init_state: bool;
+  }
 
   let is_registered = SymbolicUtility.Mixed.is_registered
 
@@ -260,18 +262,14 @@ module SymbolicConstraints = struct
     printf "- Error cases: %d@\n" (List.length errors);
     printf "- Incomplete symbolic execution: %d@\n" (List.length failures)
 
-  type constraints_config = {
-    prune_init_state: bool;
-  }
-
-  let run config ~argument0 ?(arguments=[]) ?(vars=[]) colis =
+ let run sym_config config ~argument0 ?(arguments=[]) ?(vars=[]) colis =
     let open SymbolicUtility in
     let context = mk_context ~arguments ~vars in
-    let filesystems = Constraints.filesystems ~prune_init_state:config.backend.prune_init_state config.filesystem_spec in
+    let filesystems = Constraints.filesystems config sym_config.filesystem_spec in
     let stas = List.map Constraints.mk_state filesystems in
     let sym_stas = List.map (fun state -> Constraints.{ state; context }) stas in
     let results =
-      interp_program ~loop_limit:config.loop_limit ~stack_size:config.stack_size ~argument0
+      interp_program ~loop_limit:sym_config.loop_limit ~stack_size:sym_config.stack_size ~argument0
         sym_stas colis
     in
     print_states ~initials:stas results;
@@ -295,20 +293,19 @@ module SymbolicConstraints = struct
 end
 
 module SymbolicTransducers = struct
+  type config = SymbolicUtility.Transducers.config
 
-  type transducers_config = unit
-
-  let run config ~argument0 ?(arguments=[]) ?(vars=[]) colis =
+  let run sym_config config ~argument0 ?(arguments=[]) ?(vars=[]) colis =
       let open SymbolicUtility in
       let open Common in
       let inp =
-        let config = mk_config ~loop_limit:config.loop_limit ~stack_size:config.stack_size in
+        let config = mk_config ~loop_limit:sym_config.loop_limit ~stack_size:sym_config.stack_size in
         Input.{ config; argument0; under_condition=false } in
       let sym_stas =
         let context = mk_context ~arguments ~vars in
         let stas =
-          List.map Transducers.mk_state
-            (Transducers.filesystems config.filesystem_spec) in
+          let fs = Transducers.filesystems config sym_config.filesystem_spec in
+          List.map Transducers.mk_state fs in
         List.map (fun state -> Transducers.{ state; context }) stas in
       let results = SymbolicUtility.Mixed.interp_program_transducers inp sym_stas colis in
       exit_code results

--- a/src/colis.ml
+++ b/src/colis.ml
@@ -262,7 +262,7 @@ module SymbolicConstraints = struct
     printf "- Error cases: %d@\n" (List.length errors);
     printf "- Incomplete symbolic execution: %d@\n" (List.length failures)
 
- let run sym_config config ~argument0 ?(arguments=[]) ?(vars=[]) colis =
+  let run config sym_config ~argument0 ?(arguments=[]) ?(vars=[]) colis =
     let open SymbolicUtility in
     let context = mk_context ~arguments ~vars in
     let filesystems = Constraints.filesystems config sym_config.filesystem_spec in
@@ -273,7 +273,7 @@ module SymbolicConstraints = struct
         sym_stas colis
     in
     print_states ~initials:stas results;
-    exit_code results
+    exit (exit_code results)
 
   (** {3 For colis-batch} *)
 
@@ -295,7 +295,7 @@ end
 module SymbolicTransducers = struct
   type config = SymbolicUtility.Transducers.config
 
-  let run sym_config config ~argument0 ?(arguments=[]) ?(vars=[]) colis =
+  let run config sym_config ~argument0 ?(arguments=[]) ?(vars=[]) colis =
       let open SymbolicUtility in
       let open Common in
       let inp =
@@ -308,5 +308,5 @@ module SymbolicTransducers = struct
           List.map Transducers.mk_state fs in
         List.map (fun state -> Transducers.{ state; context }) stas in
       let results = SymbolicUtility.Mixed.interp_program_transducers inp sym_stas colis in
-      exit_code results
+      exit (exit_code results)
 end

--- a/src/colis.mli
+++ b/src/colis.mli
@@ -103,47 +103,16 @@ module Constraints = Colis_constraints
 (** The symbolic interpreter using constraints on the mixed backend of SymbolicUtility *)
 module SymbolicConstraints : sig
   open Constraints
-  open Common
 
-  type filesystem = SymbolicUtility.Constraints.filesystem = {
-    root: Var.t;
-    clause: Clause.sat_conj;
-    root0: Var.t option;
-  }
-
-  type state = SymbolicUtility.Constraints.state = {
-      filesystem: filesystem;
-      stdin: string list;
-      stdout: Stdout.t;
-      log: Stdout.t;
-    }
-
-  type sym_state = SymbolicUtility.Constraints.sym_state = {
-    context : Context.context;
-    state : state;
-  }
+  type state = SymbolicUtility.Constraints.state
+  type sym_state = SymbolicUtility.Constraints.sym_state
 
   (** Test if an utility is registerered in the mixed backend (the actual backend for this
       module) *)
   val is_registered : string -> bool
 
-  (** [compile_fs_spec root conj fs_spec] creates a disjunction that represents the conjunction [conj] with constraints representing the filesystem specified by [fs_spec] *)
-  val add_fs_spec_to_clause : Var.t -> Clause.sat_conj -> FilesystemSpec.t -> Clause.sat_conj list
-
-  (* Create a state corresponding to a conjunction *)
-  val to_state : prune_init_state:bool -> root:Var.t -> Clause.sat_conj -> state
-
-  (* Create a symbolic states by adding context to a stringe *)
-  val to_symbolic_state : vars:(string * string) list -> arguments:string list -> state -> sym_state
-
   (* Wrapper around [SymbolicUtility.Mixed.interp_program] (sic!) *)
   val interp_program : loop_limit:int -> stack_size:int -> argument0:string -> sym_state list -> Language.Syntax.program -> (state list * state list * state list)
-
-  val print_state : Format.formatter -> ?id:string -> state -> unit
-
-  val print_states : initials:state list -> (state list * state list * state list) -> unit
-
-  val exit_code : (state list * state list * state list) -> int
 
   type config = {
     prune_init_state: bool;
@@ -154,10 +123,26 @@ module SymbolicConstraints : sig
     (** Maximum height of the call stack in symbolic execution *)
   }
 
-  val run : config -> FilesystemSpec.t -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> unit
+  val run : config -> FilesystemSpec.t -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
+
+  val print_state : Format.formatter -> ?id:string -> state -> unit
+
+  val print_states : initials:state list -> (state list * state list * state list) -> unit
+
+  (** {3 For colis-batch} *)
+
+  (** [compile_fs_spec root conj fs_spec] creates a disjunction that represents the conjunction [conj] with constraints representing the filesystem specified by [fs_spec] *)
+  val add_fs_spec_to_clause : Var.t -> Clause.sat_conj -> FilesystemSpec.t -> Clause.sat_conj list
+
+  (* Create a state corresponding to a conjunction *)
+  val to_state : prune_init_state:bool -> root:Var.t -> Clause.sat_conj -> state
+
+  (* Create a symbolic states by adding context to a stringe *)
+  val to_symbolic_state : vars:(string * string) list -> arguments:string list -> state -> sym_state
 end
 
 (** The symbolic interpreter using transducers *)
 module SymbolicTransducers : sig
-  val run : FilesystemSpec.t -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> unit
+
+  val run : loop_limit:int -> stack_size:int -> FilesystemSpec.t -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
 end

--- a/src/colis.mli
+++ b/src/colis.mli
@@ -100,11 +100,10 @@ module Constraints = Colis_constraints
 
 (** {1 The interpreters} *)
 
-type 'backend config = {
+type sym_config = {
   loop_limit: int; (** Maximum number of iterations of while loops in symbolic execution *)
   stack_size: int; (** Maximum height of the call stack in symbolic execution *)
   filesystem_spec : FilesystemSpec.t; (** Specification of the initial filesystem *)
-  backend : 'backend;
 }
 
 (** The symbolic interpreter using constraints on the mixed backend of SymbolicUtility *)
@@ -113,6 +112,9 @@ module SymbolicConstraints : sig
 
   type state = SymbolicUtility.Constraints.state
   type sym_state = SymbolicUtility.Constraints.sym_state
+  type config = SymbolicUtility.Constraints.config = {
+    prune_init_state: bool; (** Prune the initial symbolic state during symbolic execution for a faster execution *)
+  }
 
   (** Test if an utility is registerered in the mixed backend (the actual backend for this
       module) *)
@@ -121,11 +123,7 @@ module SymbolicConstraints : sig
   (* Wrapper around [SymbolicUtility.Mixed.interp_program] (sic!) *)
   val interp_program : loop_limit:int -> stack_size:int -> argument0:string -> sym_state list -> Language.Syntax.program -> (state list * state list * state list)
 
-  type constraints_config = {
-    prune_init_state: bool; (** Prune the initial symbolic state during symbolic execution for a faster execution *)
-  }
-
-  val run : constraints_config config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
+  val run : sym_config -> config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
 
   val print_state : Format.formatter -> ?id:string -> state -> unit
 
@@ -145,8 +143,6 @@ end
 
 (** The symbolic interpreter using transducers *)
 module SymbolicTransducers : sig
-
-  type transducers_config = unit
-
-  val run : transducers_config config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
+  type config = SymbolicUtility.Transducers.config
+  val run : sym_config -> config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
 end

--- a/src/colis.mli
+++ b/src/colis.mli
@@ -100,6 +100,13 @@ module Constraints = Colis_constraints
 
 (** {1 The interpreters} *)
 
+type 'backend config = {
+  loop_limit: int; (** Maximum number of iterations of while loops in symbolic execution *)
+  stack_size: int; (** Maximum height of the call stack in symbolic execution *)
+  filesystem_spec : FilesystemSpec.t; (** Specification of the initial filesystem *)
+  backend : 'backend;
+}
+
 (** The symbolic interpreter using constraints on the mixed backend of SymbolicUtility *)
 module SymbolicConstraints : sig
   open Constraints
@@ -114,16 +121,11 @@ module SymbolicConstraints : sig
   (* Wrapper around [SymbolicUtility.Mixed.interp_program] (sic!) *)
   val interp_program : loop_limit:int -> stack_size:int -> argument0:string -> sym_state list -> Language.Syntax.program -> (state list * state list * state list)
 
-  type config = {
-    prune_init_state: bool;
-    (** Prune the initial symbolic state during symbolic execution for a faster execution *)
-    loop_limit: int;
-    (** Maximum number of iterations of while loops in symbolic execution *)
-    stack_size: int;
-    (** Maximum height of the call stack in symbolic execution *)
+  type constraints_config = {
+    prune_init_state: bool; (** Prune the initial symbolic state during symbolic execution for a faster execution *)
   }
 
-  val run : config -> FilesystemSpec.t -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
+  val run : constraints_config config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
 
   val print_state : Format.formatter -> ?id:string -> state -> unit
 
@@ -144,5 +146,7 @@ end
 (** The symbolic interpreter using transducers *)
 module SymbolicTransducers : sig
 
-  val run : loop_limit:int -> stack_size:int -> FilesystemSpec.t -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
+  type transducers_config = unit
+
+  val run : transducers_config config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
 end

--- a/src/colis.mli
+++ b/src/colis.mli
@@ -123,7 +123,7 @@ module SymbolicConstraints : sig
   (* Wrapper around [SymbolicUtility.Mixed.interp_program] (sic!) *)
   val interp_program : loop_limit:int -> stack_size:int -> argument0:string -> sym_state list -> Language.Syntax.program -> (state list * state list * state list)
 
-  val run : sym_config -> config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
+  val run : config -> sym_config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> unit
 
   val print_state : Format.formatter -> ?id:string -> state -> unit
 
@@ -144,5 +144,5 @@ end
 (** The symbolic interpreter using transducers *)
 module SymbolicTransducers : sig
   type config = SymbolicUtility.Transducers.config
-  val run : sym_config -> config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> int
+  val run : config -> sym_config -> argument0:string -> ?arguments:(string list) -> ?vars:((string * string) list) -> colis -> unit
 end

--- a/src/colis_cmd.ml
+++ b/src/colis_cmd.ml
@@ -107,35 +107,36 @@ let speclist =
   let open Arg in
   let open Internals.Options in
   align [
-    "--run",               Unit (set_action Run),         " Concrete execution (default)";
-    "--run-symbolic",      Unit (set_action RunSymbolic), " Symbolic execution with constraints backend";
-    "--symbolic-backend",  String set_symbolic_backend,   "BACKEND Set backend of symbolic execution (constraints or transducers)";
-    "--shell",             Unit (set_source Shell),       " Use the shell parser (default)";
-    "--colis",             Unit (set_source Colis),       " Use the colis parser" ;
-    "--external-sources",  Set_string external_sources,   "DIR Import absolute sources from DIR";
-    "--print-colis",       Unit (set_action PrintColis),  " Print the CoLiS script";
-    "--print-shell",       Unit (set_action PrintShell),  " Print the Shell script";
-    "--var",               String set_var,                " VAR=VAL Set and export variable VAR to VAL in the interpreter";
-    "--realworld",         Set real_world,                " Use system utilities in concrete execution";
-    "--add-symbolic-fs",   String add_symbolic_fs,        "FILE Add files and directories from FILE to the initially empty symbolic file system (One file or directory per line; directories end with '/')";
-    "--prune-init-state",  Set prune_init_state,          " Prune the initial state in symbolic execution";
-    "--loop-limit",        Int ((:=) loop_limit),         sprintf "LIMIT Set limit for symbolic execution of while loops to LIMIT (default: %d)" !loop_limit;
-    "--cpu-time-limit",    Float ((:=) cpu_time_limit),   "LIMIT Set CPU time limit for symbolic execution to LIMIT in seconds (default: none)";
-    "--memory-limit",      String set_memory_limit,       "LIMIT Set memory limit for symbolic execution to LIMIT in bytes (default: none)";
-    "--stack-size",        Int ((:=) stack_size),         sprintf "SIZE Set the stack size for symbolic execution to SIZE (default: %d)" !stack_size;
-    "--print-states",      String ((:=)print_states_dir), "DIR Save symbolic states as dot files in directory DIR";
-    "--unknown-behaviour", String set_unknown_behaviour,  "BHV Behaviour for unknown utilities: raising an exception (by default), like an unsupported utility (incomplete behaviour), or as a colis-level error";
-    "--",                  Rest add_argument,             "ARG... Pass all further arguments directly to the CoLiS interpreter";
+    "--run",               Unit (set_action Run),          " Concrete execution (default)";
+    "--run-symbolic",      Unit (set_action RunSymbolic),  " Symbolic execution with constraints backend";
+    "--symbolic-backend",  String set_symbolic_backend,    "BACKEND Set backend of symbolic execution (constraints or transducers)";
+    "--shell",             Unit (set_source Shell),        " Use the shell parser (default)";
+    "--colis",             Unit (set_source Colis),        " Use the colis parser" ;
+    "--external-sources",  Set_string external_sources,    "DIR Import absolute sources from DIR";
+    "--print-colis",       Unit (set_action PrintColis),   " Print the CoLiS script";
+    "--print-shell",       Unit (set_action PrintShell),   " Print the Shell script";
+    "--var",               String set_var,                 " VAR=VAL Set and export variable VAR to VAL in the interpreter";
+    "--realworld",         Set real_world,                 " Use system utilities in concrete execution";
+    "--add-symbolic-fs",   String add_symbolic_fs,         "FILE Add files and directories from FILE to the initially empty symbolic file system (One file or directory per line; directories end with '/')";
+    "--prune-init-state",  Set prune_init_state,           " Prune the initial state in symbolic execution";
+    "--loop-limit",        Int ((:=) loop_limit),          sprintf "LIMIT Set limit for symbolic execution of while loops to LIMIT (default: %d)" !loop_limit;
+    "--cpu-time-limit",    Float ((:=) cpu_time_limit),    "LIMIT Set CPU time limit for symbolic execution to LIMIT in seconds (default: none)";
+    "--memory-limit",      String set_memory_limit,        "LIMIT Set memory limit for symbolic execution to LIMIT in bytes (default: none)";
+    "--stack-size",        Int ((:=) stack_size),          sprintf "SIZE Set the stack size for symbolic execution to SIZE (default: %d)" !stack_size;
+    "--print-states",      String ((:=) print_states_dir), "DIR Save symbolic states as dot files in directory DIR";
+    "--unknown-behaviour", String set_unknown_behaviour,   "BHV Behaviour for unknown utilities: raising an exception (by default), like an unsupported utility (incomplete behaviour), or as a colis-level error";
+    "--",                  Rest add_argument,              "ARG... Pass all further arguments directly to the CoLiS interpreter";
   ]
 
 let usage =
   sprintf
     ("Usage: %s <action> <syntax-opts> [--var VAR=VAL ...] FILE [--] [ARG...]\n"^^
-     "       <action>: [--run <opts> <concrete-opts> | --run-symbolic [<opts> <constraints-opts>|<transducers-opts>] | --print-colis | --print-shell]\n"^^
+     "       <action>: [--run <opts> <concrete-opts> | --run-symbolic [<symbolic-opts>] [<constraints-opts> <opts>|<transducers-opts>] | --print-colis | --print-shell]\n"^^
      "       <opts>: [--unknown-behaviour EXCEPTION|UNSUPPORTED|ERROR]\n"^^
      "       <concrete-opts>: [--realworld]\n"^^
-     "       <constraints-opts>: [--symbolic-backend CONSTRAINTS] [--symbolic-fs FS] [--prune-init-state] [--loop-boundary] [--print-states DIR]\n"^^
-     "       <transducers-opts>: --symbolic-backend TRANSDUCERS [--symbolic-fs FS]\n"^^
+     "       <symbolic-opts>: [--loop-limit LIMIT] [--stack-size SIZE] [--symbolic-fs FS]\n"^^
+     "       <constraints-opts>: [--symbolic-backend CONSTRAINTS] [--prune-init-state] [--print-states DIR]\n"^^
+     "       <transducers-opts>: --symbolic-backend TRANSDUCERS\n"^^
      "       <syntax-opts>: [--shell [--external-sources DIR] | --colis]")
     Sys.argv.(0)
 

--- a/src/colis_cmd.ml
+++ b/src/colis_cmd.ml
@@ -166,21 +166,26 @@ let main () =
   | Run ->
      Concrete.run ~argument0 ~arguments ~vars program
   | RunSymbolic -> begin
-      let fs_spec = get_symbolic_fs () in
       match get_symbolic_backend () with
       | ConstraintsBackend ->
         let open SymbolicConstraints in
         let config = {
-          prune_init_state = !prune_init_state;
           loop_limit = !loop_limit;
           stack_size = !stack_size;
+          filesystem_spec = get_symbolic_fs ();
+          backend = {prune_init_state = !prune_init_state};
         } in
-        let res = run config fs_spec ~argument0 ~arguments ~vars program in
+        let res = run config ~argument0 ~arguments ~vars program in
         exit res
       | TransducersBackend ->
         let open SymbolicTransducers in
-        let loop_limit = !loop_limit and stack_size = !stack_size in
-        let res = run ~loop_limit ~stack_size fs_spec ~argument0 ~arguments ~vars program in
+        let config = {
+          loop_limit = !loop_limit;
+          stack_size = !stack_size;
+          filesystem_spec = get_symbolic_fs ();
+          backend = ();
+        } in
+        let res = run config ~argument0 ~arguments ~vars program in
         exit res
     end
   | PrintColis ->

--- a/src/colis_cmd.ml
+++ b/src/colis_cmd.ml
@@ -166,27 +166,17 @@ let main () =
   | Run ->
      Concrete.run ~argument0 ~arguments ~vars program
   | RunSymbolic -> begin
+      let sym_config = {
+        loop_limit = !loop_limit;
+        stack_size = !stack_size;
+        filesystem_spec = get_symbolic_fs ();
+      } in
       match get_symbolic_backend () with
       | ConstraintsBackend ->
-        let open SymbolicConstraints in
-        let config = {
-          loop_limit = !loop_limit;
-          stack_size = !stack_size;
-          filesystem_spec = get_symbolic_fs ();
-          backend = {prune_init_state = !prune_init_state};
-        } in
-        let res = run config ~argument0 ~arguments ~vars program in
-        exit res
+        let config = {SymbolicConstraints.prune_init_state = !prune_init_state} in
+        exit (SymbolicConstraints.run sym_config config ~argument0 ~arguments ~vars program)
       | TransducersBackend ->
-        let open SymbolicTransducers in
-        let config = {
-          loop_limit = !loop_limit;
-          stack_size = !stack_size;
-          filesystem_spec = get_symbolic_fs ();
-          backend = ();
-        } in
-        let res = run config ~argument0 ~arguments ~vars program in
-        exit res
+        exit (SymbolicTransducers.run sym_config () ~argument0 ~arguments ~vars program)
     end
   | PrintColis ->
     Language.print_colis program;

--- a/src/colis_cmd.ml
+++ b/src/colis_cmd.ml
@@ -20,9 +20,9 @@ let get_action, set_action =
 
 let get_symbolic_backend, set_symbolic_backend =
   let symbolic_backend = ref None in
-  let parse_symbolic_backend = function
-    | "CONSTRAINTS" -> ConstraintsBackend
-    | "TRANSDUCERS" -> TransducersBackend
+  let parse_symbolic_backend str = match String.lowercase_ascii str with
+    | "constraints" -> ConstraintsBackend
+    | "transducers" -> TransducersBackend
     | _ -> raise (Arg.Bad "invalid backend (should be constraints or transducers)") in
   (fun () ->
      match !symbolic_backend with
@@ -96,10 +96,10 @@ let set_unknown_behaviour str =
     raise (Arg.Bad "--unknown-utilities can only be specified with --run or --run-symbolic")
   | _ ->
     let behaviour =
-      match str with
-      | "EXCEPTION" -> Exception
-      | "INCOMPLETE" -> Incomplete
-      | "ERROR" -> Error
+      match String.lowercase_ascii str with
+      | "exception" -> Exception
+      | "incomplete" -> Incomplete
+      | "error" -> Error
       | _ -> raise (Arg.Bad "Invalid value for unknown behaviour") in
     unknown_behaviour := behaviour
 

--- a/src/colis_cmd.ml
+++ b/src/colis_cmd.ml
@@ -162,24 +162,27 @@ let main () =
   let argument0 = file in
   let arguments = get_arguments () in
   let vars = get_vars () in
+
   match get_action () with
   | Run ->
      Concrete.run ~argument0 ~arguments ~vars program
-  | RunSymbolic -> begin
-      let sym_config = {
-        loop_limit = !loop_limit;
-        stack_size = !stack_size;
-        filesystem_spec = get_symbolic_fs ();
-      } in
+  | RunSymbolic ->
+    let run_backend =
       match get_symbolic_backend () with
       | ConstraintsBackend ->
-        let config = {SymbolicConstraints.prune_init_state = !prune_init_state} in
-        exit (SymbolicConstraints.run sym_config config ~argument0 ~arguments ~vars program)
+        let open SymbolicConstraints in
+        run {prune_init_state = !prune_init_state}
       | TransducersBackend ->
-        exit (SymbolicTransducers.run sym_config () ~argument0 ~arguments ~vars program)
-    end
+        let open SymbolicTransducers in
+        run () in
+    let sym_config = {
+      loop_limit = !loop_limit;
+      stack_size = !stack_size;
+      filesystem_spec = get_symbolic_fs ();
+    } in
+    run_backend sym_config ~argument0 ~arguments ~vars program
   | PrintColis ->
-    Language.print_colis program;
+    Language.print_colis program
   | PrintShell ->
     eprintf "Printing Shell is not supported yet.@.";
     exit 9 (* FIXME *)

--- a/src/symbolic/filesystemSpec.ml
+++ b/src/symbolic/filesystemSpec.ml
@@ -59,17 +59,17 @@ let add_channel cin t =
     assert false
   with End_of_file -> !t
 
-let rec compile root t =
-  SMap.fold (fun name node -> Clause.and_ @@ compile_node root name node) t Clause.true_
+let rec compile_constraints root t =
+  SMap.fold (fun name node -> Clause.and_ @@ compile_constraints_node root name node) t Clause.true_
 
-and compile_node x name node =
+and compile_constraints_node x name node =
   let f = Feat.from_string name in
   let open Clause in
   exists @@ fun y ->
   feat x f y &
   match node with
   | File -> ndir y
-  | Dir t -> dir y & compile y t
+  | Dir t -> dir y & compile_constraints y t
 
 let rec pp fmt t =
   SMap.bindings t |>

--- a/src/symbolic/filesystemSpec.mli
+++ b/src/symbolic/filesystemSpec.mli
@@ -1,5 +1,3 @@
-open Colis_constraints
-
 (** Simple specification of filessytems (with a translation to feature constraints) *)
 type t
 
@@ -26,7 +24,7 @@ val add_channel : in_channel -> t -> t
 
 (** Compile the specification of a filesystem into a feature constraint at the given root
     variable.*)
-val compile : Var.t -> t -> Clause.t
+val compile_constraints : Colis_constraints.Var.t -> t -> Colis_constraints.Clause.t
 
 (** Print the FS spec as a tree *)
 val pp : Format.formatter -> t -> unit

--- a/src/symbolic/symbolicUtility.ml
+++ b/src/symbolic/symbolicUtility.ml
@@ -95,9 +95,9 @@ module MakeInterpreter (Filesystem: FILESYSTEM) = struct
   let is_registered = Hashtbl.mem table
 
   let () =
-    (* TODO Register all essential commands as:
+    (* TODO Register all essential utilities as:
        [incomplete ~utility "not implemented"] *)
-    (* TODO Register all known unknown POSIX utilities, if any:
+    (* TODO Register all known unknown utilities, if any:
        [error ~utility "command not found"] *)
     ()
 

--- a/src/symbolic/symbolicUtility.ml
+++ b/src/symbolic/symbolicUtility.ml
@@ -362,11 +362,13 @@ module Constraints = struct
   include MakeInterpreter (ConstraintsImplementation)
   include MakeSpecifications (ConstraintsImplementation)
 
-  let filesystems ~prune_init_state fs_spec =
+  type config = { prune_init_state : bool }
+
+  let filesystems config fs_spec =
     let root = Var.fresh () in
     let fs_clause = FilesystemSpec.compile_constraints root fs_spec in
     let conjs = Clause.add_to_sat_conj fs_clause Clause.true_sat_conj in
-    let root0 = if prune_init_state then None else Some root in
+    let root0 = if config.prune_init_state then None else Some root in
     List.map (fun clause -> {clause; root; root0}) conjs
 end
 
@@ -385,8 +387,10 @@ module Transducers = struct
   include MakeInterpreter (TransducersImplementation)
   include MakeSpecifications (TransducersImplementation)
 
-  let filesystems : FilesystemSpec.t -> filesystem list =
-    fun _ -> failwith "SymbolicUtility.Transducers.filesystems"
+  type config = unit
+
+  let filesystems : config -> FilesystemSpec.t -> filesystem list =
+    fun _ _ -> failwith "SymbolicUtility.Transducers.filesystems"
 end
 
 (* Mixed *)

--- a/src/symbolic/symbolicUtility.mli
+++ b/src/symbolic/symbolicUtility.mli
@@ -46,6 +46,8 @@ module MakeInterpreter (Filesystem: FILESYSTEM) : sig
     log: Stdout.t;
   }
 
+  val mk_state : Filesystem.filesystem -> state
+
   (** {1 Interpretation of a colis program} *)
 
   type sym_state = {
@@ -235,6 +237,7 @@ module Constraints : sig
     with type filesystem = ConstraintsImplementation.filesystem
   include module type of MakeInterpreter (ConstraintsImplementation)
   include module type of MakeSpecifications (ConstraintsImplementation)
+  val filesystems : prune_init_state:bool -> FilesystemSpec.t -> filesystem list
 end
 
 (** {1 Transducers} *)
@@ -254,6 +257,7 @@ module Transducers : sig
     with type filesystem = TransducersImplementation.filesystem
   include module type of MakeInterpreter (TransducersImplementation)
   include module type of MakeSpecifications (TransducersImplementation)
+  val filesystems : FilesystemSpec.t -> filesystem list
 end
 
 (** {1 Mixed constraints/transducers} *)

--- a/src/symbolic/symbolicUtility.mli
+++ b/src/symbolic/symbolicUtility.mli
@@ -237,7 +237,10 @@ module Constraints : sig
     with type filesystem = ConstraintsImplementation.filesystem
   include module type of MakeInterpreter (ConstraintsImplementation)
   include module type of MakeSpecifications (ConstraintsImplementation)
-  val filesystems : prune_init_state:bool -> FilesystemSpec.t -> filesystem list
+  type config = {
+    prune_init_state: bool; (** Prune the initial symbolic state during symbolic execution for a faster execution *)
+  }
+  val filesystems : config -> FilesystemSpec.t -> filesystem list
 end
 
 (** {1 Transducers} *)
@@ -257,7 +260,8 @@ module Transducers : sig
     with type filesystem = TransducersImplementation.filesystem
   include module type of MakeInterpreter (TransducersImplementation)
   include module type of MakeSpecifications (TransducersImplementation)
-  val filesystems : FilesystemSpec.t -> filesystem list
+  type config = unit
+  val filesystems : config -> FilesystemSpec.t -> filesystem list
 end
 
 (** {1 Mixed constraints/transducers} *)


### PR DESCRIPTION
Add an option `--symbolic-backend` to the command line interface to select either the constraints-backend or the transducers-backend.